### PR TITLE
DAL-16 코스정보 DB에 삽입하기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation("org.hibernate.orm:hibernate-spatial:6.6.15.Final")
 
     // Secret & Config
-    implementation("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0")
+    implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.3.0"))
     implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.3.0")
     implementation("org.springframework.cloud:spring-cloud-starter-bootstrap:4.2.1")
 
@@ -64,6 +64,7 @@ dependencies {
     // Infrastructure
     implementation("com.oracle.database.jdbc:ojdbc11:23.8.0.25.04")
     implementation("org.redisson:redisson-spring-boot-starter:3.47.0")
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1") // 3.3버전에 이슈가 있어서 올리면 안됨
     // implementation("org.hibernate.search:hibernate-search-backend-elasticsearch:7.2.3.Final") // OpenSearch를 사용하게되면 주석 해제
 
     // JWT
@@ -73,6 +74,12 @@ dependencies {
 
     // Documentation
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+
+    // Utilities
+    implementation("io.jenetics:jpx:3.2.1")
+
+    // Map
+    implementation("com.google.maps:google-maps-services:2.2.0")
 
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/kr/dallyeobom/client/GoogleMapsClient.kt
+++ b/src/main/kotlin/kr/dallyeobom/client/GoogleMapsClient.kt
@@ -1,0 +1,66 @@
+package kr.dallyeobom.client
+
+import com.google.maps.GeoApiContext
+import com.google.maps.GeocodingApi
+import com.google.maps.StaticMapsRequest
+import com.google.maps.model.AddressComponent
+import com.google.maps.model.EncodedPolyline
+import com.google.maps.model.LatLng
+import com.google.maps.model.Size
+import kr.dallyeobom.config.properties.GoogleMapsProperties
+import org.springframework.stereotype.Component
+
+@Component
+class GoogleMapsClient(
+    googleMapsProperties: GoogleMapsProperties,
+) {
+    private val context: GeoApiContext =
+        GeoApiContext
+            .Builder()
+            .apiKey(googleMapsProperties.apiKey)
+            .build()
+
+    fun getStaticMap(path: List<LatLng>): ByteArray =
+        CustomStaticMapsRequest(context, STATIC_MAP_SIZE)
+            .path(
+                EncodedPolyline(path),
+                color = STATIC_MAP_PATH_COLOR,
+                weight = STATIC_MAP_PATH_WEIGHT,
+            ).scale(STATIC_MAP_SCALE)
+            .await()
+            .imageData
+
+    fun getLocation(latLng: LatLng): Array<AddressComponent> =
+        GeocodingApi
+            .reverseGeocode(context, latLng)
+            .language("ko")
+            .await()
+            .first()
+            .addressComponents
+
+    // 기본적으로 encodedPath와 color, weight를 동시에 사용할 수 없으나 우리는 필요하다
+    // 따라서 StaticMapsRequest를 상속받아 새로운 메소드를 만든다
+    private class CustomStaticMapsRequest(
+        context: GeoApiContext,
+        size: Size,
+    ) : StaticMapsRequest(context) {
+        init {
+            this.size(size)
+        }
+
+        fun path(
+            path: EncodedPolyline,
+            color: String,
+            weight: Int,
+        ): StaticMapsRequest = paramAddToList("path", "weight:$weight|color:$color|enc:" + path.encodedPath)
+    }
+
+    companion object {
+        private const val STATIC_MAP_PATH_COLOR = "0xE38756FF"
+        private const val STATIC_MAP_PATH_WEIGHT = 10
+        private const val STATIC_MAP_SCALE = 2
+
+        @JvmStatic
+        private val STATIC_MAP_SIZE = Size(400, 400)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/client/TourApiClient.kt
+++ b/src/main/kotlin/kr/dallyeobom/client/TourApiClient.kt
@@ -1,0 +1,155 @@
+package kr.dallyeobom.client
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.google.maps.model.LatLng
+import kr.dallyeobom.config.properties.TourApiProperties
+import org.springframework.stereotype.Component
+import org.springframework.util.MultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@Component
+class TourApiClient(
+    tourApiProperties: TourApiProperties,
+) {
+    private val restClient: RestClient =
+        RestClient
+            .builder()
+            .baseUrl("https://apis.data.go.kr")
+            .build()
+
+    val defaultQueryParams =
+        MultiValueMap.fromSingleValue(
+            mapOf(
+                "serviceKey" to tourApiProperties.apiKey,
+                "MobileOS" to "AND",
+                "MobileApp" to URLEncoder.encode("달려봄", StandardCharsets.UTF_8),
+                "_type" to "json",
+            ),
+        )
+
+    fun getCourseList(
+        numOfRows: Int = 1000,
+        pageNo: Int = 1,
+    ) = restClient
+        .get()
+        .uri(
+            UriComponentsBuilder
+                .fromPath("/B551011/Durunubi/courseList")
+                .queryParams(defaultQueryParams)
+                .queryParam("numOfRows", numOfRows)
+                .queryParam("pageNo", pageNo)
+                .build(true)
+                .toUri(),
+        ).retrieve()
+        .body(CourseListResponse::class.java)!!
+        .response.body.items.item
+
+    // 1km 반경 내에 있는 관광지 이미지 가져오기 - 그걸로 코스 대표 이미지로 사용
+    fun getLocationImageUrl(latLng: LatLng) =
+        restClient
+            .get()
+            .uri(
+                UriComponentsBuilder
+                    .fromPath("/B551011/KorService2/locationBasedList2")
+                    .queryParams(defaultQueryParams)
+                    .queryParam("numOfRows", 10)
+                    .queryParam("pageNo", 1)
+                    .queryParam("arrange", "S") // 정렬 기준: 이미지 있는 데이터중에 거리순
+                    .queryParam("mapX", latLng.lng)
+                    .queryParam("mapY", latLng.lat)
+                    .queryParam("radius", 1000) // 1km 반경
+                    .build(true)
+                    .toUri(),
+            ).retrieve()
+            .body(LocationImageResponse::class.java)!!
+            .response.body.items
+            ?.item
+            ?.firstOrNull()
+            ?.firstimage
+
+    fun getFileWithStream(fileUrl: String) =
+        restClient
+            .get()
+            .uri(fileUrl)
+            .retrieve()
+            .body(ByteArray::class.java)
+            ?.inputStream()
+}
+
+// 왜 이런 복잡한 구조로 되어있는지 모르겠지만, 주는 그대로 받으려면 이렇게 해야한다
+data class CourseListResponse(
+    val response: Response,
+) {
+    data class Response(
+        val body: ResponseBody,
+    )
+
+    data class ResponseBody(
+        val items: ResponseBodyItems,
+    )
+
+    data class ResponseBodyItems(
+        val item: List<ListResponseBodyItem>,
+    )
+
+    data class ListResponseBodyItem(
+        val crsKorNm: String,
+        val crsLevel: String,
+        val crsContents: String,
+        val gpxpath: String,
+    )
+}
+
+data class LocationImageResponse(
+    val response: Response,
+) {
+    data class Response(
+        val body: ResponseBody,
+    )
+
+    data class ResponseBody(
+        // 왜 이렇게 만들었는지 모르겠는데 items는 분명 JsonObject인데 값이 없으면 {}나 null로 오지 않고 ""로 온다
+        // 그래서 커스텀 디시리얼라이저를 만들어서 ""일 때 null로 처리한다
+        @JsonDeserialize(using = ItemsDeserializer::class)
+        val items: ResponseBodyItems?,
+    )
+
+    data class ResponseBodyItems(
+        val item: List<ListResponseBodyItem>,
+    )
+
+    data class ListResponseBodyItem(
+        val firstimage: String,
+    )
+}
+
+class ItemsDeserializer : JsonDeserializer<LocationImageResponse.ResponseBodyItems>() {
+    override fun deserialize(
+        p: JsonParser,
+        ctxt: DeserializationContext,
+    ): LocationImageResponse.ResponseBodyItems? {
+        val mapper = (p.codec as ObjectMapper)
+        val node = p.codec.readTree<JsonNode>(p)
+
+        return when {
+            node.isTextual && node.asText() == "" -> {
+                null
+            }
+            else -> {
+                mapper.readValue(
+                    node.traverse(mapper),
+                    object : TypeReference<LocationImageResponse.ResponseBodyItems>() {},
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/config/properties/GoogleMapsProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/GoogleMapsProperties.kt
@@ -1,0 +1,8 @@
+package kr.dallyeobom.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "client.google-maps")
+data class GoogleMapsProperties(
+    val apiKey: String,
+)

--- a/src/main/kotlin/kr/dallyeobom/config/properties/JwtProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/JwtProperties.kt
@@ -1,4 +1,4 @@
-package kr.dallyeobom.config
+package kr.dallyeobom.config.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/src/main/kotlin/kr/dallyeobom/config/properties/ObjectStorageProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/ObjectStorageProperties.kt
@@ -1,0 +1,9 @@
+package kr.dallyeobom.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "spring.cloud.aws.s3")
+data class ObjectStorageProperties(
+    val bucket: String,
+    val cdnUrl: String,
+)

--- a/src/main/kotlin/kr/dallyeobom/config/properties/TourApiProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/TourApiProperties.kt
@@ -1,0 +1,8 @@
+package kr.dallyeobom.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "client.tour-api")
+data class TourApiProperties(
+    val apiKey: String,
+)

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
@@ -1,0 +1,21 @@
+package kr.dallyeobom.controller.course
+
+import kr.dallyeobom.service.CourseService
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/course")
+class CourseController(
+    private val courseService: CourseService,
+) {
+    // 해당 API는 관광데이터 API를 통해 코스를 생성하는 API로, 1번만 실행해서 DB에 해당 데이터들이 들어갔다면 더이상 쓸모가 없다
+    // 그러나 DB를 날려버리고 다시 채울때가 있다면 그때는 주석 해제 후 사용할것
+    // @PostMapping("/insert-tour-api-course")
+    @ResponseStatus(CREATED)
+    fun insertTourApiCourse() {
+        courseService.createCoursesWithTourApi()
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/dto/CourseCreateDto.kt
+++ b/src/main/kotlin/kr/dallyeobom/dto/CourseCreateDto.kt
@@ -1,0 +1,22 @@
+package kr.dallyeobom.dto
+
+import com.google.maps.model.LatLng
+import kr.dallyeobom.entity.CourseCreatorType
+import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.util.subStringOrReturn
+
+// 아래 DTO에만 데이터를 담아주면 나머지 데이터는 CourseService::saveCourse 메소드 내부에서 알아서 필요한 데이터 추출해서 사용함
+data class CourseCreateDto(
+    // Backing Properties
+    private val _name: String,
+    private val _description: String,
+    val courseLevel: CourseLevel,
+    val image: String?,
+    val creatorType: CourseCreatorType,
+    val creatorId: Long?,
+    val path: List<LatLng>,
+) {
+    // 길이 넘는건 자름
+    val name = _name.subStringOrReturn(30)
+    val description = _description.subStringOrReturn(500) // 두루누비 API에선 1000자 넘는 데이터도 있는데 굳이 다 저장해야할까 싶어서 최대 500자로 자름
+}

--- a/src/main/kotlin/kr/dallyeobom/entity/Course.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/Course.kt
@@ -18,18 +18,18 @@ import org.locationtech.jts.geom.Point
 @SQLDelete(sql = "UPDATE course SET deleted_datetime = current_timestamp WHERE id = ?")
 @SQLRestriction("deleted_datetime IS NULL")
 class Course(
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 30)
     var name: String,
     @Column(nullable = false, length = 500)
     var description: String,
     @Column(nullable = false)
     @Enumerated(EnumType.ORDINAL)
     var courseLevel: CourseLevel,
-    @Column(length = 50)
+    @Column(length = 60)
     var image: String?,
     @Column(nullable = false, length = 50)
     var location: String,
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 60)
     var overviewImage: String,
     @Column(nullable = false, updatable = false, length = 10)
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionImage.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionImage.kt
@@ -18,7 +18,7 @@ class CourseCompletionImage(
     @ManyToOne
     @JoinColumn(nullable = false, updatable = false)
     val completion: CourseCompletionHistory,
-    @Column(nullable = false, updatable = false, length = 50)
+    @Column(nullable = false, updatable = false, length = 60)
     val image: String,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
@@ -1,0 +1,8 @@
+package kr.dallyeobom.repository
+
+import kr.dallyeobom.entity.Course
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CourseRepository : JpaRepository<Course, Long>

--- a/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
@@ -1,0 +1,41 @@
+package kr.dallyeobom.repository
+
+import io.awspring.cloud.s3.S3Template
+import kr.dallyeobom.config.properties.ObjectStorageProperties
+import org.springframework.stereotype.Repository
+import software.amazon.awssdk.services.s3.S3Client
+import java.io.InputStream
+
+@Repository
+class ObjectStorageRepository(
+    private val objectStorageProperties: ObjectStorageProperties,
+    private val s3Template: S3Template,
+    private val s3Client: S3Client,
+) {
+    fun upload(
+        path: String,
+        key: String,
+        stream: InputStream,
+    ): String {
+        val result = s3Template.upload(objectStorageProperties.bucket, path + key, stream)
+        return result.filename
+    }
+
+    fun getDownloadUrl(key: String): String = "${objectStorageProperties.cdnUrl}/$key"
+
+    fun delete(key: String) { // 참고로 delete는 실시간 반영되지 않음
+        s3Template.deleteObject(objectStorageProperties.bucket, key)
+    }
+
+    // WARNING: 이 메소드는 모든 객체를 삭제합니다. 주의해서 사용하세요.
+    fun deleteAll() {
+        s3Template.listObjects(objectStorageProperties.bucket, "").map { obj ->
+            delete(obj.filename)
+        }
+    }
+
+    companion object {
+        const val COURSE_OVERVIEW_IMAGE_PATH = "course/overview/"
+        const val COURSE_IMAGE_PATH = "course/image/"
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -1,0 +1,238 @@
+package kr.dallyeobom.service
+
+import com.google.maps.model.AddressComponentType
+import com.google.maps.model.LatLng
+import io.jenetics.jpx.GPX
+import kr.dallyeobom.client.GoogleMapsClient
+import kr.dallyeobom.client.TourApiClient
+import kr.dallyeobom.dto.CourseCreateDto
+import kr.dallyeobom.entity.Course
+import kr.dallyeobom.entity.CourseCreatorType
+import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.repository.CourseRepository
+import kr.dallyeobom.repository.ObjectStorageRepository
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.springframework.stereotype.Service
+import java.io.ByteArrayInputStream
+import java.util.Locale
+import java.util.PriorityQueue
+import java.util.UUID
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+@Service
+class CourseService(
+    private val courseRepository: CourseRepository,
+    private val objectStorageRepository: ObjectStorageRepository,
+    private val googleMapsClient: GoogleMapsClient,
+    private val tourApiClient: TourApiClient,
+) {
+    // 관광데이터 API를 통해 경로를 가져오고, DB를 채워넣는 메소드
+    // 해당 메소드는 멱등성보장이 되지 않는다. 따라서 여러번 호출하면 중복된 코스가 생성된다.
+    fun createCoursesWithTourApi(): List<Course> {
+        val courses = tourApiClient.getCourseList()
+        return courses.map { course ->
+            val gpx = GPX.Reader.of(GPX.Reader.Mode.LENIENT).read(tourApiClient.getFileWithStream(course.gpxpath))
+            val path =
+                gpx.tracks
+                    .flatMap { it.segments }
+                    .flatMap { it.points }
+                    .map { LatLng(it.latitude.toDegrees(), it.longitude.toDegrees()) }
+            val image =
+                tourApiClient.getLocationImageUrl(path.first())?.let { imageUrl ->
+                    val fileName =
+                        UUID.randomUUID().toString() + "." + // 중복나지 않도록 UUID 사용
+                            imageUrl.split(".").last().lowercase(Locale.getDefault()) // 확장자 추출후 소문자로 통일
+                    try {
+                        objectStorageRepository.upload(
+                            ObjectStorageRepository.COURSE_IMAGE_PATH,
+                            fileName,
+                            tourApiClient.getFileWithStream(imageUrl)!!,
+                        )
+                    } catch (e: Exception) {
+                        // 왜 인지 모르겠는데 해당 API가 실행 안되는 좌표들이 간혹 있다. 500에러 발생하면 재시도 해도 안됨
+                        // 이 경우에는 null로 처리
+                        null
+                    }
+                }
+            saveCourse(
+                CourseCreateDto(
+                    course.crsKorNm,
+                    course.crsContents,
+                    CourseLevel.entries[course.crsLevel.toInt() - 1],
+                    image,
+                    CourseCreatorType.SYSTEM,
+                    null,
+                    path,
+                ),
+            )
+        }
+    }
+
+    private fun saveCourse(courseDto: CourseCreateDto): Course {
+        val fileName = UUID.randomUUID().toString() + ".png" // 중복나지 않도록 UUID 사용, 확장자는 png로 고정되어 있음
+
+        val simplified = simplifyPath(courseDto.path)
+        val imageBytes = googleMapsClient.getStaticMap(simplified)
+
+        val path =
+            GeometryFactory()
+                .createLineString(
+                    courseDto.path.map { Coordinate(it.lat, it.lng) }.toTypedArray(),
+                ).also {
+                    it.srid = WGS84_SRID
+                }
+        val startPoint =
+            GeometryFactory()
+                .createPoint(
+                    Coordinate(
+                        courseDto.path.first().lat,
+                        courseDto.path.first().lng,
+                    ),
+                ).also {
+                    it.srid = WGS84_SRID
+                }
+
+        // 코스의 시작좌표를 기준으로 해당 코스의 지역을 결정함
+        val reverseGeocodingResult = googleMapsClient.getLocation(courseDto.path.first())
+
+        val location =
+            (
+                // 도
+                reverseGeocodingResult
+                    .firstOrNull { it.types.contains(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1) }
+                    ?.shortName
+                    ?.let { "$it " } ?: ""
+            ) +
+                (
+                    // 시 혹은 군
+                    reverseGeocodingResult
+                        .firstOrNull { it.types.contains(AddressComponentType.LOCALITY) }
+                        ?.shortName
+                        ?.let { "$it " } ?: ""
+                ) +
+                (
+                    // 구, 면, 읍 중 하나
+                    reverseGeocodingResult
+                        .firstOrNull { it.types.contains(AddressComponentType.SUBLOCALITY_LEVEL_2) }
+                        ?.shortName ?: ""
+                )
+
+        return courseRepository.save(
+            Course(
+                name = courseDto.name,
+                description = courseDto.description,
+                courseLevel = courseDto.courseLevel,
+                image = courseDto.image,
+                location = location,
+                creatorType = courseDto.creatorType,
+                creatorId = courseDto.creatorId,
+                path = path,
+                overviewImage =
+                    objectStorageRepository.upload(
+                        ObjectStorageRepository.COURSE_OVERVIEW_IMAGE_PATH,
+                        fileName,
+                        ByteArrayInputStream(imageBytes),
+                    ),
+                length = calculateTotalDistance(simplified),
+                startPoint = startPoint,
+            ),
+        )
+    }
+
+    // 어차피 썸네일에선 경로를 자세하게 보여줄 필요가 없으므로 효율적인 표현을 위해
+    // VisvalingamWhyatt 알고리즘을 사용하여 경로를 단순화
+    fun simplifyPath(points: List<LatLng>): List<LatLng> {
+        if (points.size <= MAX_SIMPLIFIED_POINTS) return points.toList()
+
+        val n = points.size
+        val prev = IntArray(n) { it - 1 }.also { it[0] = -1 }
+        val next = IntArray(n) { it + 1 }.also { it[n - 1] = -1 }
+        val area = DoubleArray(n) { Double.POSITIVE_INFINITY }
+
+        for (i in 1 until n - 1) area[i] = triangleArea(points[prev[i]], points[i], points[next[i]])
+
+        val pq = PriorityQueue<Int> { a, b -> area[a].compareTo(area[b]) }
+        for (i in 1 until n - 1) pq.add(i)
+
+        var remaining = n
+        while (remaining > MAX_SIMPLIFIED_POINTS && pq.isNotEmpty()) {
+            val idx = pq.poll()
+            if (area[idx].isNaN()) continue
+
+            val p = prev[idx]
+            val q = next[idx]
+            if (p != -1) next[p] = q
+            if (q != -1) prev[q] = p
+            remaining--
+            area[idx] = Double.NaN
+
+            if (p != -1 && prev[p] != -1) {
+                area[p] = triangleArea(points[prev[p]], points[p], points[q])
+                pq.add(p)
+            }
+            if (q != -1 && next[q] != -1) {
+                area[q] = triangleArea(points[p], points[q], points[next[q]])
+                pq.add(q)
+            }
+        }
+
+        val result = ArrayList<LatLng>(remaining)
+        var i = 0
+        while (i != -1) {
+            result.add(points[i])
+            i = next[i]
+        }
+        return result
+    }
+
+    private fun triangleArea(
+        a: LatLng,
+        b: LatLng,
+        c: LatLng,
+    ): Double {
+        val ax = a.lng
+        val ay = a.lat
+        val bx = b.lng
+        val by = b.lat
+        val cx = c.lng
+        val cy = c.lat
+        return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 0.5)
+    }
+
+    private fun calculateTotalDistance(points: List<LatLng>): Int {
+        if (points.size < 2) return 0
+
+        var total = 0.0
+        for (i in 0 until points.lastIndex) {
+            total += haversine(points[i], points[i + 1])
+        }
+        return total.toInt() // 단위: 미터 (m)
+    }
+
+    private fun haversine(
+        p1: LatLng,
+        p2: LatLng,
+    ): Double {
+        val dLat = Math.toRadians(p2.lat - p1.lat)
+        val dLng = Math.toRadians(p2.lng - p1.lng)
+        val a =
+            sin(dLat / 2).pow(2.0) +
+                cos(Math.toRadians(p1.lat)) *
+                cos(Math.toRadians(p2.lat)) *
+                sin(dLng / 2).pow(2.0)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return EARTH_RADIUS * c
+    }
+
+    companion object {
+        private const val WGS84_SRID = 4326 // WGS84 SRID
+        private const val MAX_SIMPLIFIED_POINTS = 1000 // 최대 단순화된 포인트 수
+        private const val EARTH_RADIUS = 6371000.0 // 지구 반지름 (미터 단위)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/ConnectionFinder.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/ConnectionFinder.kt
@@ -1,0 +1,16 @@
+package kr.dallyeobom.util
+
+import com.zaxxer.hikari.pool.HikariProxyConnection
+import org.geolatte.geom.codec.db.oracle.DefaultConnectionFinder
+import java.lang.reflect.Field
+import java.sql.Connection
+
+class ConnectionFinder : DefaultConnectionFinder() {
+    // hibernate spatial이 커넥션을 못 찾는 문제 해결하기 위한 코드.
+    // https://stackoverflow.com/questions/47753350/couldnt-get-at-the-oraclespatial-connection-object-from-the-preparedstatement
+    override fun find(con: Connection): Connection {
+        val delegate: Field = (con as HikariProxyConnection).javaClass.superclass.getDeclaredField("delegate")
+        delegate.setAccessible(true)
+        return delegate.get(con) as Connection
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/StringUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/StringUtil.kt
@@ -1,0 +1,8 @@
+package kr.dallyeobom.util
+
+fun String.subStringOrReturn(limit: Int): String =
+    if (this.length > limit) {
+        this.substring(limit)
+    } else {
+        this
+    }

--- a/src/main/kotlin/kr/dallyeobom/util/jwt/JwtUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/jwt/JwtUtil.kt
@@ -4,7 +4,7 @@ import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
-import kr.dallyeobom.config.JwtProperties
+import kr.dallyeobom.config.properties.JwtProperties
 import org.redisson.api.RedissonClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/src/main/resources/application-database.yml
+++ b/src/main/resources/application-database.yml
@@ -7,6 +7,8 @@ spring:
     open-in-view: false
     properties:
       hibernate:
+        spatial:
+          connection_finder: kr.dallyeobom.util.ConnectionFinder # Oracle DB에서 Spatial 기능을 사용하기 위한 설정
         default_batch_fetch_size: 100
   datasource:
     driver-class-name: oracle.jdbc.OracleDriver


### PR DESCRIPTION
### 개요
- 관광데이터 API에서 제공하는 코스를 우리 DB에 넣자
- 추후 코스가 더 추가될 상황을 고려하여 코스 추가 로직을 재활용 가능하게 작업하자

### 변경사항
1. 두루누비API로 코스를 받아옴 
2. GPX파일을 파싱하고 해서 코스 정보를 만듬
3. 국문 관광데이터 API에서 코스의 첫번째 좌표 기준으로 대표사진을 찾음
4. 구글맵 API에서 코스의 첫번째 좌표 기준으로 지역을 찾음
5. 코스의 경로를 정적맵에 그려주는 구글맵 API를 사용하여 그리고 ObjectStorage에 저장


### 리뷰어에게 하고 싶은 말
- 작업 완료후 DB에 값도 채웠으니 확인 부탁드리구요
- insertTourApiCourse메소드는 실행하면 DB에 데이터가 중복되니 테스트라도 돌려보시지 않으시면 좋을것 같습니다 :)
