### PR TITLE
DAL-19 기록 등록 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 
     // Utilities
     implementation("io.jenetics:jpx:3.2.1")
+    implementation("commons-io:commons-io:2.19.0")
 
     // Map
     implementation("com.google.maps:google-maps-services:2.2.0")

--- a/src/main/kotlin/kr/dallyeobom/config/WebMvcConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package kr.dallyeobom.config
+
+import kr.dallyeobom.util.LoginUserResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(LoginUserResolver())
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/config/swagger/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/swagger/ApiDocsConfig.kt
@@ -6,12 +6,18 @@ import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
+import kr.dallyeobom.util.LoginUser
+import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 
 @Configuration
 class ApiDocsConfig {
+    init {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser::class.java)
+    }
+
     @Bean
     fun openAPI(): OpenAPI =
         OpenAPI()

--- a/src/main/kotlin/kr/dallyeobom/config/swagger/ApiDocsConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/swagger/ApiDocsConfig.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.models.info.Info
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
-import kr.dallyeobom.util.LoginUser
+import kr.dallyeobom.util.LoginUserId
 import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders.AUTHORIZATION
 @Configuration
 class ApiDocsConfig {
     init {
-        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser::class.java)
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUserId::class.java)
     }
 
     @Bean

--- a/src/main/kotlin/kr/dallyeobom/config/swagger/SwaggerTag.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/swagger/SwaggerTag.kt
@@ -5,5 +5,6 @@ object SwaggerTag {
     const val TERM: String = "A. 약관 API"
     const val AUTH: String = "B. 인증 API"
     const val COURSE: String = "C. 코스 API"
+    const val COURSE_COMPLETION_HISTORY: String = "D. 코스 완료 기록 API"
     const val TEMPORAL_AUTH: String = "Y. 임시 인증 API"
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
@@ -1,5 +1,6 @@
 package kr.dallyeobom.controller.course
 
+import jakarta.validation.constraints.Positive
 import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
@@ -30,6 +31,8 @@ class CourseController(
 
     @GetMapping("/{id}")
     override fun getCourseDetail(
-        @PathVariable id: Long,
+        @PathVariable
+        @Positive(message = "코스 ID는 양수여야 합니다.")
+        id: Long,
     ): CourseDetailResponse = courseService.getCourseDetail(id)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/request/NearByCourseSearchRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/request/NearByCourseSearchRequest.kt
@@ -1,20 +1,28 @@
 package kr.dallyeobom.controller.course.request
 
-import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Positive
 import org.hibernate.validator.constraints.Range
 
 data class NearByCourseSearchRequest(
-    @field:Parameter(description = "위도", example = "37.5665")
+    @field:Schema(description = "위도", example = "37.5665")
     @field:Range(min = -90, max = 90, message = "위도는 -90에서 90 사이의 값이어야 합니다.")
     val latitude: Double,
-    @field:Parameter(description = "경도", example = "126.978")
+    @field:Schema(description = "경도", example = "126.978")
     @field:Range(min = -180, max = 180, message = "경도는 -180에서 180 사이의 값이어야 합니다.")
     val longitude: Double,
-    @field:Parameter(description = "검색 범위 (미터 단위) - 값이 없으면 1000", example = "1000")
+    @field:Schema(
+        description = "검색 범위 (미터 단위) - 값이 없으면 1000",
+        example = "1000",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
     @field:Positive(message = "검색 범위는 양수여야 합니다.")
     val radius: Int = 1000,
-    @field:Parameter(description = "기대하는 응답 개수 - 값이 없으면 10", example = "10")
+    @field:Schema(
+        description = "기대하는 응답 개수 - 값이 없으면 10",
+        example = "10",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
     @field:Positive(message = "최대 응답 개수는 양수여야 합니다.")
     val maxCount: Int = 10,
 )

--- a/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseDetailResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseDetailResponse.kt
@@ -1,6 +1,7 @@
 package kr.dallyeobom.controller.course.response
 
 import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.dto.LatLngDto
 import kr.dallyeobom.entity.Course
 import kr.dallyeobom.entity.CourseLevel
 
@@ -21,7 +22,7 @@ data class CourseDetailResponse(
     var overViewImageUrl: String,
     @Schema(description = "코스 길이 (미터 단위)", example = "15000")
     val length: Int,
-    val path: List<LatLng>,
+    val path: List<LatLngDto>,
 ) {
     companion object {
         fun from(
@@ -37,14 +38,7 @@ data class CourseDetailResponse(
             location = course.location,
             overViewImageUrl = overViewImageUrl,
             length = course.length,
-            path = course.path.coordinates.map { LatLng(it.x, it.y) },
+            path = course.path.coordinates.map { LatLngDto(it.x, it.y) },
         )
     }
-
-    data class LatLng(
-        @Schema(description = "위도", example = "37.5665")
-        val latitude: Double,
-        @Schema(description = "경도", example = "126.978")
-        val longitude: Double,
-    )
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -31,7 +31,7 @@ class CourseCompletionHistoryController(
         request: CourseCompletionCreateRequest,
         @RequestPart(required = false)
         courseImage: MultipartFile?,
-    ): CourseCompletionCreateResponse = courseCompletionHistoryService.createCourseCompletionHistory(user, request, courseImage)
+    ): CourseCompletionCreateResponse = courseCompletionHistoryService.createCourseCompletionHistory(userId, request, courseImage)
 
     @GetMapping("/{id}")
     override fun getCourseCompletionHistoryDetail(

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -1,12 +1,16 @@
 package kr.dallyeobom.controller.courseCompletionHistory
 
+import jakarta.validation.constraints.Positive
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.entity.User
 import kr.dallyeobom.service.CourseCompletionHistoryService
 import kr.dallyeobom.util.LoginUser
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
@@ -28,6 +32,12 @@ class CourseCompletionHistoryController(
         request: CourseCompletionCreateRequest,
         @RequestPart(required = false)
         courseImage: MultipartFile?,
-    ): CourseCompletionCreateResponse =
-        CourseCompletionCreateResponse.from(courseCompletionHistoryService.createCourseCompletionHistory(user, request, courseImage))
+    ): CourseCompletionCreateResponse = courseCompletionHistoryService.createCourseCompletionHistory(user, request, courseImage)
+
+    @GetMapping("/{id}")
+    override fun getCourseCompletionHistoryDetail(
+        @PathVariable
+        @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
+        id: Long,
+    ): CourseCompletionHistoryDetailResponse = courseCompletionHistoryService.getCourseCompletionHistoryDetail(id)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -1,0 +1,32 @@
+package kr.dallyeobom.controller.courseCompletionHistory
+
+import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
+import kr.dallyeobom.entity.User
+import kr.dallyeobom.service.CourseCompletionHistoryService
+import kr.dallyeobom.util.LoginUser
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/v1/course-completion-history")
+class CourseCompletionHistoryController(
+    private val courseCompletionHistoryService: CourseCompletionHistoryService,
+) : CourseCompletionHistoryControllerSpec {
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping(consumes = [MULTIPART_FORM_DATA_VALUE])
+    override fun createCourseCompletionHistory(
+        @LoginUser
+        user: User,
+        request: CourseCompletionCreateRequest,
+        @RequestPart(required = false)
+        courseImage: MultipartFile?,
+    ): CourseCompletionCreateResponse =
+        CourseCompletionCreateResponse.from(courseCompletionHistoryService.createCourseCompletionHistory(user, request, courseImage))
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -4,9 +4,8 @@ import jakarta.validation.constraints.Positive
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
-import kr.dallyeobom.entity.User
 import kr.dallyeobom.service.CourseCompletionHistoryService
-import kr.dallyeobom.util.LoginUser
+import kr.dallyeobom.util.LoginUserId
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,8 +25,8 @@ class CourseCompletionHistoryController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(consumes = [MULTIPART_FORM_DATA_VALUE])
     override fun createCourseCompletionHistory(
-        @LoginUser
-        user: User,
+        @LoginUserId
+        userId: Long,
         @RequestPart
         request: CourseCompletionCreateRequest,
         @RequestPart(required = false)

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -24,6 +24,7 @@ class CourseCompletionHistoryController(
     override fun createCourseCompletionHistory(
         @LoginUser
         user: User,
+        @RequestPart
         request: CourseCompletionCreateRequest,
         @RequestPart(required = false)
         courseImage: MultipartFile?,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -10,7 +10,6 @@ import kr.dallyeobom.config.swagger.SwaggerTag
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
-import kr.dallyeobom.entity.User
 import kr.dallyeobom.util.validator.MaxFileSize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.multipart.MultipartFile
@@ -44,7 +43,7 @@ interface CourseCompletionHistoryControllerSpec {
         ],
     )
     fun createCourseCompletionHistory(
-        user: User,
+        userId: Long,
         @Validated request: CourseCompletionCreateRequest,
         @MaxFileSize
         courseImage: MultipartFile?,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -3,6 +3,8 @@ package kr.dallyeobom.controller.courseCompletionHistory
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.dallyeobom.config.swagger.SwaggerTag
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.entity.User
@@ -10,6 +12,7 @@ import kr.dallyeobom.util.validator.MaxFileSize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.multipart.MultipartFile
 
+@Tag(name = SwaggerTag.COURSE_COMPLETION_HISTORY)
 interface CourseCompletionHistoryControllerSpec {
     @Operation(
         summary = "코스 완주 기록 생성",

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -2,11 +2,14 @@ package kr.dallyeobom.controller.courseCompletionHistory
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Positive
 import kr.dallyeobom.config.swagger.SwaggerTag
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.entity.User
 import kr.dallyeobom.util.validator.MaxFileSize
 import org.springframework.validation.annotation.Validated
@@ -46,4 +49,19 @@ interface CourseCompletionHistoryControllerSpec {
         @MaxFileSize
         courseImage: MultipartFile?,
     ): CourseCompletionCreateResponse
+
+    @Operation(
+        summary = "코스 완주기록 상세 조회",
+        description = "코스 완주기록 ID를 입력받아 해당 기록의 상세 정보를 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "코스 완주 기록 상세 정보"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 - 완주 기록 ID가 양수가 아님", content = arrayOf(Content())),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 기록 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun getCourseCompletionHistoryDetail(
+        @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
+        @Schema(description = "상세조회 하고자 하는 완주 기록의 ID", example = "1")
+        id: Long,
+    ): CourseCompletionHistoryDetailResponse
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -1,0 +1,46 @@
+package kr.dallyeobom.controller.courseCompletionHistory
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
+import kr.dallyeobom.entity.User
+import kr.dallyeobom.util.validator.MaxFileSize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.multipart.MultipartFile
+
+interface CourseCompletionHistoryControllerSpec {
+    @Operation(
+        summary = "코스 완주 기록 생성",
+        description = "코스 완주 기록을 생성합니다.",
+        responses = [
+            ApiResponse(responseCode = "201", description = "코스 완주 기록 생성 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = """
+        잘못된 요청:
+        • 코스 ID가 양수가 아님  
+        • 리뷰의 길이가 1자 미만이거나 300자를 초과함
+        • 소요시간이 양수가 아님
+        • 경로가 비어있음
+        • 경로의 위도 또는 경도가 범위를 벗어남
+        • 코스 공개 설정이 잘못됨
+        • 코스 ID가 null이고 공개 설정이 PRIVATE인대 코스 생성 정보를 넣은경우
+        • 공개 설정이 PUBLIC인데 생성 정보가 없는경우
+        • 코스 설명이 1자 미만이거나 500자를 초과함
+        • 코스명이 1자 미만이거나 30자를 초과함
+        • 파일 사이즈가 1MB를 초과함
+      """,
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "404", description = "존재하지 않는 코스 ID를 입력한 경우", content = arrayOf(Content())),
+        ],
+    )
+    fun createCourseCompletionHistory(
+        user: User,
+        @Validated request: CourseCompletionCreateRequest,
+        @MaxFileSize
+        courseImage: MultipartFile?,
+    ): CourseCompletionCreateResponse
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionCreateRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionCreateRequest.kt
@@ -1,0 +1,55 @@
+package kr.dallyeobom.controller.courseCompletionHistory.request
+
+import com.google.maps.model.LatLng
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Positive
+import kr.dallyeobom.dto.LatLngDto
+import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.entity.CourseVisibility
+import org.hibernate.validator.constraints.Length
+
+data class CourseCompletionCreateRequest(
+    @field:Schema(
+        description = "코스 ID - 코스 선택 후 달린 경우에만 입력",
+        example = "1",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    @field:Positive(message = "코스 ID는 양수여야 합니다.")
+    val courseId: Long?,
+    @field:Schema(description = "코스 리뷰", example = "이 코스는 정말 좋았습니다! 다음에도 또 달리고 싶어요.")
+    @field:Length(min = 1, max = 300, message = "리뷰는 최소 1자, 최대 300자까지 입력 가능합니다.")
+    var review: String,
+    @field:Schema(description = "소요시간 (초 단위)", example = "3600")
+    @field:Positive(message = "소요시간은 양수여야 합니다.")
+    val interval: Long,
+    @field:Schema(
+        description = "코스 경로",
+        example = "[{\"latitude\": 37.5665, \"longitude\": 126.978}, {\"latitude\": 37.567, \"longitude\": 126.979}]",
+    )
+    @field:Length(min = 1, message = "경로는 최소 1개의 좌표가 필요합니다.")
+    val path: List<LatLngDto>,
+    @field:Schema(
+        description = "완주한 코스 공개 설정 - courseId가 null인 경우에만 입력",
+        example = "PUBLIC",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val courseVisibility: CourseVisibility?,
+    @field:Schema(
+        description = "코스 생성 정보 - courseId가 null이고 courseVisibility가 PRIVATE가 아닌 경우에만 입력",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val courseCreateInfo: CourseCreateInfo?,
+) {
+    val latLngPath: List<LatLng> = path.map(LatLngDto::toLatLng)
+}
+
+data class CourseCreateInfo(
+    @field:Schema(description = "코스 설명", example = "서울 한강을 따라 자전거를 탈 수 있는 코스입니다.")
+    @field:Length(min = 1, max = 500, message = "코스 설명은 최소 1자, 최대 500자까지 입력 가능합니다.")
+    val description: String,
+    @field:Schema(description = "코스명", example = "서울 한강 러닝 코스")
+    @field:Length(min = 1, max = 30, message = "코스명은 최소 1자, 최대 30자까지 입력 가능합니다.")
+    val name: String,
+    @field:Schema(description = "코스 난이도", example = "LOW")
+    val courseLevel: CourseLevel,
+)

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionCreateRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionCreateRequest.kt
@@ -3,6 +3,7 @@ package kr.dallyeobom.controller.courseCompletionHistory.request
 import com.google.maps.model.LatLng
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
 import kr.dallyeobom.dto.LatLngDto
 import kr.dallyeobom.entity.CourseLevel
 import kr.dallyeobom.entity.CourseVisibility
@@ -26,7 +27,7 @@ data class CourseCompletionCreateRequest(
         description = "코스 경로",
         example = "[{\"latitude\": 37.5665, \"longitude\": 126.978}, {\"latitude\": 37.567, \"longitude\": 126.979}]",
     )
-    @field:Length(min = 1, message = "경로는 최소 1개의 좌표가 필요합니다.")
+    @field:Size(min = 1, message = "경로는 최소 1개의 좌표가 필요합니다.")
     val path: List<LatLngDto>,
     @field:Schema(
         description = "완주한 코스 공개 설정 - courseId가 null인 경우에만 입력",
@@ -40,6 +41,7 @@ data class CourseCompletionCreateRequest(
     )
     val courseCreateInfo: CourseCreateInfo?,
 ) {
+    @Schema(hidden = true)
     val latLngPath: List<LatLng> = path.map(LatLngDto::toLatLng)
 }
 

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionCreateResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionCreateResponse.kt
@@ -1,0 +1,13 @@
+package kr.dallyeobom.controller.courseCompletionHistory.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.entity.CourseCompletionHistory
+
+data class CourseCompletionCreateResponse(
+    @Schema(description = "등록된 완주기록 ID", example = "1")
+    val id: Long,
+) {
+    companion object {
+        fun from(courseCompletionHistory: CourseCompletionHistory) = CourseCompletionCreateResponse(courseCompletionHistory.id)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
@@ -1,0 +1,35 @@
+package kr.dallyeobom.controller.courseCompletionHistory.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.dto.LatLngDto
+import kr.dallyeobom.entity.CourseCompletionHistory
+
+class CourseCompletionHistoryDetailResponse(
+    @Schema(description = "코스 완료 이력 ID", example = "1")
+    val id: Long = 0L,
+    @Schema(description = "코스 ID", example = "1")
+    val courseId: Long?,
+    @Schema(description = "유저 ID", example = "1")
+    val userId: Long,
+    @Schema(description = "코스 리뷰", example = "이 코스는 정말 좋았습니다! 다음에도 또 달리고 싶어요.")
+    var review: String,
+    @Schema(description = "소요시간 (초 단위)", example = "3600")
+    val interval: Long,
+    @Schema(
+        description = "코스 경로",
+        example = "[{\"latitude\": 37.5665, \"longitude\": 126.978}, {\"latitude\": 37.567, \"longitude\": 126.979}]",
+    )
+    val path: List<LatLngDto>,
+) {
+    companion object {
+        fun from(courseCompletionHistory: CourseCompletionHistory): CourseCompletionHistoryDetailResponse =
+            CourseCompletionHistoryDetailResponse(
+                id = courseCompletionHistory.id,
+                courseId = courseCompletionHistory.course?.id,
+                userId = courseCompletionHistory.user.id,
+                review = courseCompletionHistory.review,
+                interval = courseCompletionHistory.interval.toSeconds(),
+                path = courseCompletionHistory.path.coordinates.map { LatLngDto(it.x, it.y) },
+            )
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/dto/CourseCreateDto.kt
+++ b/src/main/kotlin/kr/dallyeobom/dto/CourseCreateDto.kt
@@ -3,6 +3,7 @@ package kr.dallyeobom.dto
 import com.google.maps.model.LatLng
 import kr.dallyeobom.entity.CourseCreatorType
 import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.entity.CourseVisibility
 import kr.dallyeobom.util.subStringOrReturn
 
 // 아래 DTO에만 데이터를 담아주면 나머지 데이터는 CourseService::saveCourse 메소드 내부에서 알아서 필요한 데이터 추출해서 사용함
@@ -15,6 +16,7 @@ data class CourseCreateDto(
     val creatorType: CourseCreatorType,
     val creatorId: Long?,
     val path: List<LatLng>,
+    val visibility: CourseVisibility,
 ) {
     // 길이 넘는건 자름
     val name = _name.subStringOrReturn(30)

--- a/src/main/kotlin/kr/dallyeobom/dto/LatLngDto.kt
+++ b/src/main/kotlin/kr/dallyeobom/dto/LatLngDto.kt
@@ -1,0 +1,13 @@
+package kr.dallyeobom.dto
+
+import com.google.maps.model.LatLng
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class LatLngDto(
+    @Schema(description = "위도", example = "37.5665")
+    val latitude: Double,
+    @Schema(description = "경도", example = "126.978")
+    val longitude: Double,
+) {
+    fun toLatLng(): LatLng = LatLng(latitude, longitude)
+}

--- a/src/main/kotlin/kr/dallyeobom/entity/Course.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/Course.kt
@@ -42,6 +42,9 @@ class Course(
     val startPoint: Point,
     @Column(columnDefinition = "SDO_GEOMETRY", nullable = false, updatable = false)
     val path: LineString,
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    var visibility: CourseVisibility,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)
@@ -57,4 +60,10 @@ enum class CourseLevel {
 enum class CourseCreatorType {
     USER,
     SYSTEM,
+}
+
+enum class CourseVisibility {
+    PUBLIC,
+    PRIVATE,
+    // CREW, // 나중에 크루 기능같은게 추가되면 크루에게만 공개 같은 기능을 추가할 수 있음
 }

--- a/src/main/kotlin/kr/dallyeobom/exception/CourseCompletionHistoryNotFoundException.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/CourseCompletionHistoryNotFoundException.kt
@@ -1,0 +1,7 @@
+package kr.dallyeobom.exception
+
+class CourseCompletionHistoryNotFoundException :
+    BaseException(
+        ErrorCode.COURSE_COMPLETION_HISTORY_NOT_FOUND,
+        ErrorCode.COURSE_COMPLETION_HISTORY_NOT_FOUND.errorMessage,
+    )

--- a/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
@@ -20,6 +20,7 @@ enum class ErrorCode(
     // 리소스 NOT FOUND는 40400부터 시작
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "해당 유저를 찾을 수 없습니다."),
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, 40401, "해당 코스를 찾을 수 없습니다."),
+    COURSE_COMPLETION_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, 40402, "해당 완주 기록을 찾을 수 없습니다."),
 
     // 리소스 충돌은 40900부터 시작
     ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, 40900, "이미 사용중인 닉네임입니다."),

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
@@ -1,0 +1,6 @@
+package kr.dallyeobom.repository
+
+import kr.dallyeobom.entity.CourseCompletionHistory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CourseCompletionHistoryRepository : JpaRepository<CourseCompletionHistory, Long>

--- a/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
@@ -4,6 +4,7 @@ import io.awspring.cloud.s3.S3Template
 import kr.dallyeobom.config.properties.ObjectStorageProperties
 import org.springframework.stereotype.Repository
 import java.io.InputStream
+import java.util.UUID
 
 @Repository
 class ObjectStorageRepository(
@@ -35,5 +36,7 @@ class ObjectStorageRepository(
     companion object {
         const val COURSE_OVERVIEW_IMAGE_PATH = "course/overview/"
         const val COURSE_IMAGE_PATH = "course/image/"
+
+        fun generateFileName(extension: String): String = "${UUID.randomUUID()}.$extension" // 중복나지 않도록 UUID 사용
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -13,7 +13,7 @@ import kr.dallyeobom.exception.CourseNotFoundException
 import kr.dallyeobom.repository.CourseCompletionHistoryRepository
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
-import kr.dallyeobom.util.CourseCreteUtil
+import kr.dallyeobom.util.CourseCreateUtil
 import kr.dallyeobom.util.requireNull
 import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Service
@@ -27,7 +27,7 @@ import kotlin.jvm.optionals.getOrNull
 class CourseCompletionHistoryService(
     private val courseRepository: CourseRepository,
     private val courseCompletionHistoryRepository: CourseCompletionHistoryRepository,
-    private val courseCreteUtil: CourseCreteUtil,
+    private val courseCreateUtil: CourseCreateUtil,
     private val objectStorageRepository: ObjectStorageRepository,
 ) {
     @Transactional
@@ -44,7 +44,7 @@ class CourseCompletionHistoryService(
             } else if (request.courseVisibility != CourseVisibility.PRIVATE) {
                 requireNotNull(request.courseCreateInfo) { "코스 생성 정보가 필요합니다." }
                 requireNotNull(request.courseVisibility) { "코스 공개 설정 정보가 필요합니다." }
-                courseCreteUtil.saveCourse(
+                courseCreateUtil.saveCourse(
                     CourseCreateDto(
                         request.courseCreateInfo.name,
                         request.courseCreateInfo.description,
@@ -79,7 +79,7 @@ class CourseCompletionHistoryService(
                     course = course,
                     review = request.review,
                     interval = Duration.ofSeconds(request.interval),
-                    path = courseCreteUtil.latLngToLineString(request.latLngPath),
+                    path = courseCreateUtil.latLngToLineString(request.latLngPath),
                 ),
             ),
         )

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -1,0 +1,78 @@
+package kr.dallyeobom.service
+
+import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.dto.CourseCreateDto
+import kr.dallyeobom.entity.CourseCompletionHistory
+import kr.dallyeobom.entity.CourseCreatorType
+import kr.dallyeobom.entity.CourseVisibility
+import kr.dallyeobom.entity.User
+import kr.dallyeobom.exception.CourseNotFoundException
+import kr.dallyeobom.repository.CourseCompletionHistoryRepository
+import kr.dallyeobom.repository.CourseRepository
+import kr.dallyeobom.repository.ObjectStorageRepository
+import kr.dallyeobom.util.CourseCreteUtil
+import org.apache.commons.io.FilenameUtils
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+import java.time.Duration
+import java.util.Locale
+import kotlin.jvm.optionals.getOrNull
+
+@Service
+class CourseCompletionHistoryService(
+    private val courseRepository: CourseRepository,
+    private val courseCompletionHistoryRepository: CourseCompletionHistoryRepository,
+    private val courseCreteUtil: CourseCreteUtil,
+    private val objectStorageRepository: ObjectStorageRepository,
+) {
+    @Transactional
+    fun createCourseCompletionHistory(
+        user: User,
+        request: CourseCompletionCreateRequest,
+        courseImage: MultipartFile?,
+    ): CourseCompletionHistory {
+        val course =
+            if (request.courseId != null) {
+                courseRepository.findById(request.courseId).getOrNull() ?: throw CourseNotFoundException()
+            } else if (request.courseVisibility != CourseVisibility.PRIVATE) {
+                requireNotNull(request.courseCreateInfo) { "코스 생성 정보가 필요합니다." }
+                requireNotNull(request.courseVisibility) { "코스 공개 설정 정보가 필요합니다." }
+                courseCreteUtil.saveCourse(
+                    CourseCreateDto(
+                        request.courseCreateInfo.name,
+                        request.courseCreateInfo.description,
+                        request.courseCreateInfo.courseLevel,
+                        courseImage?.let {
+                            requireNotNull(courseImage.originalFilename) { "코스 이미지의 원본 파일명이 필요합니다." }
+                            objectStorageRepository.upload(
+                                ObjectStorageRepository.COURSE_IMAGE_PATH,
+                                ObjectStorageRepository.generateFileName(
+                                    FilenameUtils
+                                        .getExtension(courseImage.originalFilename)
+                                        .lowercase(Locale.getDefault()),
+                                ),
+                                courseImage.inputStream,
+                            )
+                        },
+                        CourseCreatorType.USER,
+                        creatorId = user.id,
+                        request.latLngPath,
+                        visibility = request.courseVisibility,
+                    ),
+                )
+            } else {
+                null
+            }
+
+        return courseCompletionHistoryRepository.save(
+            CourseCompletionHistory(
+                user = user,
+                course = course,
+                review = request.review,
+                interval = Duration.ofSeconds(request.interval),
+                path = courseCreteUtil.latLngToLineString(request.latLngPath),
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -1,11 +1,14 @@
 package kr.dallyeobom.service
 
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.dto.CourseCreateDto
 import kr.dallyeobom.entity.CourseCompletionHistory
 import kr.dallyeobom.entity.CourseCreatorType
 import kr.dallyeobom.entity.CourseVisibility
 import kr.dallyeobom.entity.User
+import kr.dallyeobom.exception.CourseCompletionHistoryNotFoundException
 import kr.dallyeobom.exception.CourseNotFoundException
 import kr.dallyeobom.repository.CourseCompletionHistoryRepository
 import kr.dallyeobom.repository.CourseRepository
@@ -32,7 +35,7 @@ class CourseCompletionHistoryService(
         user: User,
         request: CourseCompletionCreateRequest,
         courseImage: MultipartFile?,
-    ): CourseCompletionHistory {
+    ): CourseCompletionCreateResponse {
         val course =
             if (request.courseId != null) {
                 requireNull(request.courseVisibility) { "코스 공개 설정 정보가 존재합니다" }
@@ -68,14 +71,23 @@ class CourseCompletionHistoryService(
                 null
             }
 
-        return courseCompletionHistoryRepository.save(
-            CourseCompletionHistory(
-                user = user,
-                course = course,
-                review = request.review,
-                interval = Duration.ofSeconds(request.interval),
-                path = courseCreteUtil.latLngToLineString(request.latLngPath),
+        return CourseCompletionCreateResponse.from(
+            courseCompletionHistoryRepository.save(
+                CourseCompletionHistory(
+                    user = user,
+                    course = course,
+                    review = request.review,
+                    interval = Duration.ofSeconds(request.interval),
+                    path = courseCreteUtil.latLngToLineString(request.latLngPath),
+                ),
             ),
         )
+    }
+
+    fun getCourseCompletionHistoryDetail(id: Long): CourseCompletionHistoryDetailResponse {
+        val courseCompletionHistory =
+            courseCompletionHistoryRepository.findById(id).orElseThrow { CourseCompletionHistoryNotFoundException() }
+
+        return CourseCompletionHistoryDetailResponse.from(courseCompletionHistory)
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -7,12 +7,12 @@ import kr.dallyeobom.dto.CourseCreateDto
 import kr.dallyeobom.entity.CourseCompletionHistory
 import kr.dallyeobom.entity.CourseCreatorType
 import kr.dallyeobom.entity.CourseVisibility
-import kr.dallyeobom.entity.User
 import kr.dallyeobom.exception.CourseCompletionHistoryNotFoundException
 import kr.dallyeobom.exception.CourseNotFoundException
 import kr.dallyeobom.repository.CourseCompletionHistoryRepository
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
+import kr.dallyeobom.repository.UserRepository
 import kr.dallyeobom.util.CourseCreateUtil
 import kr.dallyeobom.util.requireNull
 import org.apache.commons.io.FilenameUtils
@@ -29,10 +29,11 @@ class CourseCompletionHistoryService(
     private val courseCompletionHistoryRepository: CourseCompletionHistoryRepository,
     private val courseCreateUtil: CourseCreateUtil,
     private val objectStorageRepository: ObjectStorageRepository,
+    private val userRepository: UserRepository,
 ) {
     @Transactional
     fun createCourseCompletionHistory(
-        user: User,
+        userId: Long,
         request: CourseCompletionCreateRequest,
         courseImage: MultipartFile?,
     ): CourseCompletionCreateResponse {
@@ -62,7 +63,7 @@ class CourseCompletionHistoryService(
                             )
                         },
                         CourseCreatorType.USER,
-                        creatorId = user.id,
+                        creatorId = userId,
                         request.latLngPath,
                         visibility = request.courseVisibility,
                     ),
@@ -75,7 +76,7 @@ class CourseCompletionHistoryService(
         return CourseCompletionCreateResponse.from(
             courseCompletionHistoryRepository.save(
                 CourseCompletionHistory(
-                    user = user,
+                    user = userRepository.findById(userId).get(), // 없을수가 없는 정보라 get() 사용
                     course = course,
                     review = request.review,
                     interval = Duration.ofSeconds(request.interval),

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -11,6 +11,7 @@ import kr.dallyeobom.repository.CourseCompletionHistoryRepository
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
 import kr.dallyeobom.util.CourseCreteUtil
+import kr.dallyeobom.util.requireNull
 import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -34,6 +35,8 @@ class CourseCompletionHistoryService(
     ): CourseCompletionHistory {
         val course =
             if (request.courseId != null) {
+                requireNull(request.courseVisibility) { "코스 공개 설정 정보가 존재합니다" }
+                requireNull(request.courseCreateInfo) { "코스 생성 정보가 존재합니다" }
                 courseRepository.findById(request.courseId).getOrNull() ?: throw CourseNotFoundException()
             } else if (request.courseVisibility != CourseVisibility.PRIVATE) {
                 requireNotNull(request.courseCreateInfo) { "코스 생성 정보가 필요합니다." }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -68,6 +68,7 @@ class CourseCompletionHistoryService(
                     ),
                 )
             } else {
+                requireNull(request.courseCreateInfo) { "비공개 코스 완주 기록 시 코스 생성 정보는 불필요합니다." }
                 null
             }
 

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -4,6 +4,7 @@ import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletion
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.dto.CourseCreateDto
+import kr.dallyeobom.entity.Course
 import kr.dallyeobom.entity.CourseCompletionHistory
 import kr.dallyeobom.entity.CourseCreatorType
 import kr.dallyeobom.entity.CourseVisibility
@@ -36,55 +37,58 @@ class CourseCompletionHistoryService(
         userId: Long,
         request: CourseCompletionCreateRequest,
         courseImage: MultipartFile?,
-    ): CourseCompletionCreateResponse {
-        val course =
-            if (request.courseId != null) {
-                requireNull(request.courseVisibility) { "코스 공개 설정 정보가 존재합니다" }
-                requireNull(request.courseCreateInfo) { "코스 생성 정보가 존재합니다" }
-                courseRepository.findById(request.courseId).getOrNull() ?: throw CourseNotFoundException()
-            } else if (request.courseVisibility != CourseVisibility.PRIVATE) {
-                requireNotNull(request.courseCreateInfo) { "코스 생성 정보가 필요합니다." }
-                requireNotNull(request.courseVisibility) { "코스 공개 설정 정보가 필요합니다." }
-                courseCreateUtil.saveCourse(
-                    CourseCreateDto(
-                        request.courseCreateInfo.name,
-                        request.courseCreateInfo.description,
-                        request.courseCreateInfo.courseLevel,
-                        courseImage?.let {
-                            requireNotNull(courseImage.originalFilename) { "코스 이미지의 원본 파일명이 필요합니다." }
-                            objectStorageRepository.upload(
-                                ObjectStorageRepository.COURSE_IMAGE_PATH,
-                                ObjectStorageRepository.generateFileName(
-                                    FilenameUtils
-                                        .getExtension(courseImage.originalFilename)
-                                        .lowercase(Locale.getDefault()),
-                                ),
-                                courseImage.inputStream,
-                            )
-                        },
-                        CourseCreatorType.USER,
-                        creatorId = userId,
-                        request.latLngPath,
-                        visibility = request.courseVisibility,
-                    ),
-                )
-            } else {
-                requireNull(request.courseCreateInfo) { "비공개 코스 완주 기록 시 코스 생성 정보는 불필요합니다." }
-                null
-            }
-
-        return CourseCompletionCreateResponse.from(
+    ): CourseCompletionCreateResponse =
+        CourseCompletionCreateResponse.from(
             courseCompletionHistoryRepository.save(
                 CourseCompletionHistory(
                     user = userRepository.findById(userId).get(), // 없을수가 없는 정보라 get() 사용
-                    course = course,
+                    course = getOrCreateCourseIfNeeded(userId, request, courseImage),
                     review = request.review,
                     interval = Duration.ofSeconds(request.interval),
                     path = courseCreateUtil.latLngToLineString(request.latLngPath),
                 ),
             ),
         )
-    }
+
+    private fun getOrCreateCourseIfNeeded(
+        userId: Long,
+        request: CourseCompletionCreateRequest,
+        courseImage: MultipartFile?,
+    ): Course? =
+        if (request.courseId != null) {
+            requireNull(request.courseVisibility) { "코스 공개 설정 정보가 존재합니다" }
+            requireNull(request.courseCreateInfo) { "코스 생성 정보가 존재합니다" }
+            courseRepository.findById(request.courseId).getOrNull() ?: throw CourseNotFoundException()
+        } else if (request.courseVisibility != CourseVisibility.PRIVATE) {
+            requireNotNull(request.courseCreateInfo) { "코스 생성 정보가 필요합니다." }
+            requireNotNull(request.courseVisibility) { "코스 공개 설정 정보가 필요합니다." }
+            courseCreateUtil.saveCourse(
+                CourseCreateDto(
+                    request.courseCreateInfo.name,
+                    request.courseCreateInfo.description,
+                    request.courseCreateInfo.courseLevel,
+                    courseImage?.let {
+                        requireNotNull(courseImage.originalFilename) { "코스 이미지의 원본 파일명이 필요합니다." }
+                        objectStorageRepository.upload(
+                            ObjectStorageRepository.COURSE_IMAGE_PATH,
+                            ObjectStorageRepository.generateFileName(
+                                FilenameUtils
+                                    .getExtension(courseImage.originalFilename)
+                                    .lowercase(Locale.getDefault()),
+                            ),
+                            courseImage.inputStream,
+                        )
+                    },
+                    CourseCreatorType.USER,
+                    creatorId = userId,
+                    request.latLngPath,
+                    visibility = request.courseVisibility,
+                ),
+            )
+        } else {
+            requireNull(request.courseCreateInfo) { "비공개 코스 완주 기록 시 코스 생성 정보는 불필요합니다." }
+            null
+        }
 
     fun getCourseCompletionHistoryDetail(id: Long): CourseCompletionHistoryDetailResponse {
         val courseCompletionHistory =

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -16,7 +16,7 @@ import kr.dallyeobom.exception.CourseNotFoundException
 import kr.dallyeobom.exception.ErrorCode
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
-import kr.dallyeobom.util.CourseCreteUtil
+import kr.dallyeobom.util.CourseCreateUtil
 import org.springframework.stereotype.Service
 import java.util.Locale
 import kotlin.jvm.optionals.getOrNull
@@ -26,7 +26,7 @@ class CourseService(
     private val courseRepository: CourseRepository,
     private val objectStorageRepository: ObjectStorageRepository,
     private val tourApiClient: TourApiClient,
-    private val courseCreteUtil: CourseCreteUtil,
+    private val courseCreateUtil: CourseCreateUtil,
 ) {
     // 관광데이터 API를 통해 경로를 가져오고, DB를 채워넣는 메소드
     // 해당 메소드는 멱등성보장이 되지 않는다. 따라서 여러번 호출하면 중복된 코스가 생성된다.
@@ -61,7 +61,7 @@ class CourseService(
                         null
                     }
                 }
-            courseCreteUtil.saveCourse(
+            courseCreateUtil.saveCourse(
                 CourseCreateDto(
                     course.crsKorNm,
                     course.crsContents,

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -1,9 +1,7 @@
 package kr.dallyeobom.service
 
-import com.google.maps.model.AddressComponentType
 import com.google.maps.model.LatLng
 import io.jenetics.jpx.GPX
-import kr.dallyeobom.client.GoogleMapsClient
 import kr.dallyeobom.client.TourApiClient
 import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
@@ -12,32 +10,23 @@ import kr.dallyeobom.dto.CourseCreateDto
 import kr.dallyeobom.entity.Course
 import kr.dallyeobom.entity.CourseCreatorType
 import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.entity.CourseVisibility
 import kr.dallyeobom.exception.BaseException
 import kr.dallyeobom.exception.CourseNotFoundException
 import kr.dallyeobom.exception.ErrorCode
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.GeometryFactory
+import kr.dallyeobom.util.CourseCreteUtil
 import org.springframework.stereotype.Service
-import java.io.ByteArrayInputStream
 import java.util.Locale
-import java.util.PriorityQueue
-import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
-import kotlin.math.abs
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.pow
-import kotlin.math.sin
-import kotlin.math.sqrt
 
 @Service
 class CourseService(
     private val courseRepository: CourseRepository,
     private val objectStorageRepository: ObjectStorageRepository,
-    private val googleMapsClient: GoogleMapsClient,
     private val tourApiClient: TourApiClient,
+    private val courseCreteUtil: CourseCreteUtil,
 ) {
     // 관광데이터 API를 통해 경로를 가져오고, DB를 채워넣는 메소드
     // 해당 메소드는 멱등성보장이 되지 않는다. 따라서 여러번 호출하면 중복된 코스가 생성된다.
@@ -55,8 +44,9 @@ class CourseService(
             val image =
                 tourApiClient.getLocationImageUrl(path.first())?.let { imageUrl ->
                     val fileName =
-                        UUID.randomUUID().toString() + "." + // 중복나지 않도록 UUID 사용
-                            imageUrl.split(".").last().lowercase(Locale.getDefault()) // 확장자 추출후 소문자로 통일
+                        ObjectStorageRepository.generateFileName(
+                            imageUrl.split(".").last().lowercase(Locale.getDefault()),
+                        ) // 확장자 추출후 소문자로 통일
                     try {
                         tourApiClient.getFileWithStream(imageUrl)?.let { stream ->
                             objectStorageRepository.upload(
@@ -71,7 +61,7 @@ class CourseService(
                         null
                     }
                 }
-            saveCourse(
+            courseCreteUtil.saveCourse(
                 CourseCreateDto(
                     course.crsKorNm,
                     course.crsContents,
@@ -80,165 +70,10 @@ class CourseService(
                     CourseCreatorType.SYSTEM,
                     null,
                     path,
+                    CourseVisibility.PUBLIC,
                 ),
             )
         }
-    }
-
-    private fun saveCourse(courseDto: CourseCreateDto): Course {
-        val fileName = UUID.randomUUID().toString() + ".png" // 중복나지 않도록 UUID 사용, 확장자는 png로 고정되어 있음
-
-        val simplified = simplifyPath(courseDto.path)
-        val imageBytes = googleMapsClient.getStaticMap(simplified)
-
-        val path =
-            GeometryFactory()
-                .createLineString(
-                    courseDto.path.map { Coordinate(it.lat, it.lng) }.toTypedArray(),
-                ).also {
-                    it.srid = WGS84_SRID
-                }
-        val startPoint =
-            GeometryFactory()
-                .createPoint(
-                    Coordinate(
-                        courseDto.path.first().lat,
-                        courseDto.path.first().lng,
-                    ),
-                ).also {
-                    it.srid = WGS84_SRID
-                }
-
-        // 코스의 시작좌표를 기준으로 해당 코스의 지역을 결정함
-        val reverseGeocodingResult = googleMapsClient.getLocation(courseDto.path.first())
-
-        val location =
-            (
-                // 도
-                reverseGeocodingResult
-                    .firstOrNull { it.types.contains(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1) }
-                    ?.shortName
-                    ?.let { "$it " } ?: ""
-            ) +
-                (
-                    // 시 혹은 군
-                    reverseGeocodingResult
-                        .firstOrNull { it.types.contains(AddressComponentType.LOCALITY) }
-                        ?.shortName
-                        ?.let { "$it " } ?: ""
-                ) +
-                (
-                    // 구, 면, 읍 중 하나
-                    reverseGeocodingResult
-                        .firstOrNull { it.types.contains(AddressComponentType.SUBLOCALITY_LEVEL_2) }
-                        ?.shortName ?: ""
-                )
-
-        return courseRepository.save(
-            Course(
-                name = courseDto.name,
-                description = courseDto.description,
-                courseLevel = courseDto.courseLevel,
-                image = courseDto.image,
-                location = location,
-                creatorType = courseDto.creatorType,
-                creatorId = courseDto.creatorId,
-                path = path,
-                overviewImage =
-                    objectStorageRepository.upload(
-                        ObjectStorageRepository.COURSE_OVERVIEW_IMAGE_PATH,
-                        fileName,
-                        ByteArrayInputStream(imageBytes),
-                    ),
-                length = calculateTotalDistance(courseDto.path),
-                startPoint = startPoint,
-            ),
-        )
-    }
-
-    // 어차피 썸네일에선 경로를 자세하게 보여줄 필요가 없으므로 효율적인 표현을 위해
-    // VisvalingamWhyatt 알고리즘을 사용하여 경로를 단순화
-    fun simplifyPath(points: List<LatLng>): List<LatLng> {
-        if (points.size <= MAX_SIMPLIFIED_POINTS) return points.toList()
-
-        val n = points.size
-        val prev = IntArray(n) { it - 1 }.also { it[0] = -1 }
-        val next = IntArray(n) { it + 1 }.also { it[n - 1] = -1 }
-        val area = DoubleArray(n) { Double.POSITIVE_INFINITY }
-
-        for (i in 1 until n - 1) area[i] = triangleArea(points[prev[i]], points[i], points[next[i]])
-
-        val pq = PriorityQueue<Int> { a, b -> area[a].compareTo(area[b]) }
-        for (i in 1 until n - 1) pq.add(i)
-
-        var remaining = n
-        while (remaining > MAX_SIMPLIFIED_POINTS && pq.isNotEmpty()) {
-            val idx = pq.poll()
-            if (area[idx].isNaN()) continue
-
-            val p = prev[idx]
-            val q = next[idx]
-            if (p != -1) next[p] = q
-            if (q != -1) prev[q] = p
-            remaining--
-            area[idx] = Double.NaN
-
-            if (p != -1 && prev[p] != -1) {
-                area[p] = triangleArea(points[prev[p]], points[p], points[q])
-                pq.add(p)
-            }
-            if (q != -1 && next[q] != -1) {
-                area[q] = triangleArea(points[p], points[q], points[next[q]])
-                pq.add(q)
-            }
-        }
-
-        val result = ArrayList<LatLng>(remaining)
-        var i = 0
-        while (i != -1) {
-            result.add(points[i])
-            i = next[i]
-        }
-        return result
-    }
-
-    private fun triangleArea(
-        a: LatLng,
-        b: LatLng,
-        c: LatLng,
-    ): Double {
-        val ax = a.lng
-        val ay = a.lat
-        val bx = b.lng
-        val by = b.lat
-        val cx = c.lng
-        val cy = c.lat
-        return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 0.5)
-    }
-
-    private fun calculateTotalDistance(points: List<LatLng>): Int {
-        if (points.size < 2) return 0
-
-        var total = 0.0
-        for (i in 0 until points.lastIndex) {
-            total += haversine(points[i], points[i + 1])
-        }
-        return total.toInt() // 단위: 미터 (m)
-    }
-
-    private fun haversine(
-        p1: LatLng,
-        p2: LatLng,
-    ): Double {
-        val dLat = Math.toRadians(p2.lat - p1.lat)
-        val dLng = Math.toRadians(p2.lng - p1.lng)
-        val a =
-            sin(dLat / 2).pow(2.0) +
-                cos(Math.toRadians(p1.lat)) *
-                cos(Math.toRadians(p2.lat)) *
-                sin(dLng / 2).pow(2.0)
-        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-        return EARTH_RADIUS * c
     }
 
     fun searchNearByLocation(request: NearByCourseSearchRequest): List<NearByCourseSearchResponse> =
@@ -257,11 +92,5 @@ class CourseService(
             course.image?.let { objectStorageRepository.getDownloadUrl(it) },
             objectStorageRepository.getDownloadUrl(course.overviewImage),
         )
-    }
-
-    companion object {
-        private const val WGS84_SRID = 4326 // WGS84 SRID
-        private const val MAX_SIMPLIFIED_POINTS = 1000 // 최대 단순화된 포인트 수
-        private const val EARTH_RADIUS = 6371000.0 // 지구 반지름 (미터 단위)
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/util/AssertUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/AssertUtil.kt
@@ -1,0 +1,10 @@
+package kr.dallyeobom.util
+
+fun requireNull(
+    value: Any?,
+    lazyMessage: () -> Any,
+) {
+    if (value != null) {
+        throw IllegalArgumentException(lazyMessage().toString())
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/CourseCreateUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseCreateUtil.kt
@@ -21,7 +21,7 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 @Component
-class CourseCreteUtil(
+class CourseCreateUtil(
     private val courseRepository: CourseRepository,
     private val objectStorageRepository: ObjectStorageRepository,
     private val googleMapsClient: GoogleMapsClient,

--- a/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
@@ -1,0 +1,198 @@
+package kr.dallyeobom.util
+
+import com.google.maps.model.AddressComponentType
+import com.google.maps.model.LatLng
+import kr.dallyeobom.client.GoogleMapsClient
+import kr.dallyeobom.dto.CourseCreateDto
+import kr.dallyeobom.entity.Course
+import kr.dallyeobom.repository.CourseRepository
+import kr.dallyeobom.repository.ObjectStorageRepository
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.LineString
+import org.springframework.stereotype.Component
+import java.io.ByteArrayInputStream
+import java.util.PriorityQueue
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+@Component
+class CourseCreteUtil(
+    private val courseRepository: CourseRepository,
+    private val objectStorageRepository: ObjectStorageRepository,
+    private val googleMapsClient: GoogleMapsClient,
+) {
+    fun saveCourse(courseDto: CourseCreateDto): Course {
+        val overviewImageName = ObjectStorageRepository.generateFileName(".png") // 중복나지 않도록 UUID 사용, 확장자는 png로 고정되어 있음
+
+        val simplified = simplifyPath(courseDto.path)
+        val imageBytes = googleMapsClient.getStaticMap(simplified)
+
+        val path =
+            latLngToLineString(
+                simplified,
+            )
+        val startPoint =
+            GeometryFactory()
+                .createPoint(
+                    Coordinate(
+                        courseDto.path.first().lat,
+                        courseDto.path.first().lng,
+                    ),
+                ).also {
+                    it.srid = WGS84_SRID
+                }
+
+        // 코스의 시작좌표를 기준으로 해당 코스의 지역을 결정함
+        val reverseGeocodingResult = googleMapsClient.getLocation(courseDto.path.first())
+
+        val location =
+            (
+                // 도
+                reverseGeocodingResult
+                    .firstOrNull { it.types.contains(AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1) }
+                    ?.shortName
+                    ?.let { "$it " } ?: ""
+            ) +
+                (
+                    // 시 혹은 군
+                    reverseGeocodingResult
+                        .firstOrNull { it.types.contains(AddressComponentType.LOCALITY) }
+                        ?.shortName
+                        ?.let { "$it " } ?: ""
+                ) +
+                (
+                    // 구, 면, 읍 중 하나
+                    reverseGeocodingResult
+                        .firstOrNull { it.types.contains(AddressComponentType.SUBLOCALITY_LEVEL_2) }
+                        ?.shortName ?: ""
+                )
+
+        return courseRepository.save(
+            Course(
+                name = courseDto.name,
+                description = courseDto.description,
+                courseLevel = courseDto.courseLevel,
+                image = courseDto.image,
+                location = location,
+                creatorType = courseDto.creatorType,
+                creatorId = courseDto.creatorId,
+                path = path,
+                overviewImage =
+                    objectStorageRepository.upload(
+                        ObjectStorageRepository.COURSE_OVERVIEW_IMAGE_PATH,
+                        overviewImageName,
+                        ByteArrayInputStream(imageBytes),
+                    ),
+                length = calculateTotalDistance(courseDto.path),
+                startPoint = startPoint,
+                visibility = courseDto.visibility,
+            ),
+        )
+    }
+
+    fun latLngToLineString(points: List<LatLng>): LineString =
+        GeometryFactory()
+            .createLineString(
+                points.map { Coordinate(it.lat, it.lng) }.toTypedArray(),
+            ).also {
+                it.srid = WGS84_SRID
+            }.also {
+                it.srid = WGS84_SRID // SRID 설정
+            }
+
+    // 어차피 썸네일에선 경로를 자세하게 보여줄 필요가 없으므로 효율적인 표현을 위해
+    // VisvalingamWhyatt 알고리즘을 사용하여 경로를 단순화
+    private fun simplifyPath(points: List<LatLng>): List<LatLng> {
+        if (points.size <= MAX_SIMPLIFIED_POINTS) return points.toList()
+
+        val n = points.size
+        val prev = IntArray(n) { it - 1 }.also { it[0] = -1 }
+        val next = IntArray(n) { it + 1 }.also { it[n - 1] = -1 }
+        val area = DoubleArray(n) { Double.POSITIVE_INFINITY }
+
+        for (i in 1 until n - 1) area[i] = triangleArea(points[prev[i]], points[i], points[next[i]])
+
+        val pq = PriorityQueue<Int> { a, b -> area[a].compareTo(area[b]) }
+        for (i in 1 until n - 1) pq.add(i)
+
+        var remaining = n
+        while (remaining > MAX_SIMPLIFIED_POINTS && pq.isNotEmpty()) {
+            val idx = pq.poll()
+            if (area[idx].isNaN()) continue
+
+            val p = prev[idx]
+            val q = next[idx]
+            if (p != -1) next[p] = q
+            if (q != -1) prev[q] = p
+            remaining--
+            area[idx] = Double.NaN
+
+            if (p != -1 && prev[p] != -1) {
+                area[p] = triangleArea(points[prev[p]], points[p], points[q])
+                pq.add(p)
+            }
+            if (q != -1 && next[q] != -1) {
+                area[q] = triangleArea(points[p], points[q], points[next[q]])
+                pq.add(q)
+            }
+        }
+
+        val result = ArrayList<LatLng>(remaining)
+        var i = 0
+        while (i != -1) {
+            result.add(points[i])
+            i = next[i]
+        }
+        return result
+    }
+
+    private fun triangleArea(
+        a: LatLng,
+        b: LatLng,
+        c: LatLng,
+    ): Double {
+        val ax = a.lng
+        val ay = a.lat
+        val bx = b.lng
+        val by = b.lat
+        val cx = c.lng
+        val cy = c.lat
+        return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 0.5)
+    }
+
+    private fun calculateTotalDistance(points: List<LatLng>): Int {
+        if (points.size < 2) return 0
+
+        var total = 0.0
+        for (i in 0 until points.lastIndex) {
+            total += haversine(points[i], points[i + 1])
+        }
+        return total.toInt() // 단위: 미터 (m)
+    }
+
+    private fun haversine(
+        p1: LatLng,
+        p2: LatLng,
+    ): Double {
+        val dLat = Math.toRadians(p2.lat - p1.lat)
+        val dLng = Math.toRadians(p2.lng - p1.lng)
+        val a =
+            sin(dLat / 2).pow(2.0) +
+                cos(Math.toRadians(p1.lat)) *
+                cos(Math.toRadians(p2.lat)) *
+                sin(dLng / 2).pow(2.0)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return EARTH_RADIUS * c
+    }
+
+    companion object {
+        const val WGS84_SRID = 4326 // WGS84 SRID
+        private const val MAX_SIMPLIFIED_POINTS = 1000 // 최대 단순화된 포인트 수
+        private const val EARTH_RADIUS = 6371000.0 // 지구 반지름 (미터 단위)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
@@ -91,8 +91,6 @@ class CourseCreteUtil(
                 points.map { Coordinate(it.lat, it.lng) }.toTypedArray(),
             ).also {
                 it.srid = WGS84_SRID
-            }.also {
-                it.srid = WGS84_SRID // SRID 설정
             }
 
     // 어차피 썸네일에선 경로를 자세하게 보여줄 필요가 없으므로 효율적인 표현을 위해

--- a/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseCreteUtil.kt
@@ -36,16 +36,6 @@ class CourseCreteUtil(
             latLngToLineString(
                 simplified,
             )
-        val startPoint =
-            GeometryFactory()
-                .createPoint(
-                    Coordinate(
-                        courseDto.path.first().lat,
-                        courseDto.path.first().lng,
-                    ),
-                ).also {
-                    it.srid = WGS84_SRID
-                }
 
         // 코스의 시작좌표를 기준으로 해당 코스의 지역을 결정함
         val reverseGeocodingResult = googleMapsClient.getLocation(courseDto.path.first())
@@ -89,7 +79,7 @@ class CourseCreteUtil(
                         ByteArrayInputStream(imageBytes),
                     ),
                 length = calculateTotalDistance(courseDto.path),
-                startPoint = startPoint,
+                startPoint = path.startPoint,
                 visibility = courseDto.visibility,
             ),
         )

--- a/src/main/kotlin/kr/dallyeobom/util/LoginUser.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/LoginUser.kt
@@ -1,0 +1,6 @@
+package kr.dallyeobom.util
+
+// 현재 사용자의 정보를 컨트롤러 메서드에서 쉽게 사용할 수 있도록 하는 어노테이션
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LoginUser

--- a/src/main/kotlin/kr/dallyeobom/util/LoginUserId.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/LoginUserId.kt
@@ -3,4 +3,4 @@ package kr.dallyeobom.util
 // 현재 사용자의 정보를 컨트롤러 메서드에서 쉽게 사용할 수 있도록 하는 어노테이션
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class LoginUser
+annotation class LoginUserId

--- a/src/main/kotlin/kr/dallyeobom/util/LoginUserResolver.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/LoginUserResolver.kt
@@ -1,0 +1,33 @@
+package kr.dallyeobom.util
+
+import kr.dallyeobom.entity.User
+import kr.dallyeobom.exception.BaseException
+import kr.dallyeobom.exception.ErrorCode
+import kr.dallyeobom.service.SecurityUser
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class LoginUserResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean =
+        parameter.hasParameterAnnotation(LoginUser::class.java) && parameter.parameterType == User::class.java
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): User {
+        val authentication = SecurityContextHolder.getContext().authentication?.principal
+        // 로그인이 안됐다면 필터에서 짤렸을거라 null일 수  없긴 할텐데 혹시나 몰라 일단 null 체크를 해줌
+        return (authentication as? SecurityUser)?.user ?: throw BaseException(
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.UNAUTHORIZED.errorMessage,
+        )
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/LoginUserResolver.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/LoginUserResolver.kt
@@ -1,6 +1,5 @@
 package kr.dallyeobom.util
 
-import kr.dallyeobom.entity.User
 import kr.dallyeobom.exception.BaseException
 import kr.dallyeobom.exception.ErrorCode
 import kr.dallyeobom.service.SecurityUser
@@ -15,17 +14,17 @@ import org.springframework.web.method.support.ModelAndViewContainer
 @Component
 class LoginUserResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean =
-        parameter.hasParameterAnnotation(LoginUser::class.java) && parameter.parameterType == User::class.java
+        parameter.hasParameterAnnotation(LoginUserId::class.java) && parameter.parameterType == Long::class.java
 
     override fun resolveArgument(
         parameter: MethodParameter,
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?,
-    ): User {
+    ): Long {
         val authentication = SecurityContextHolder.getContext().authentication?.principal
         // 로그인이 안됐다면 필터에서 짤렸을거라 null일 수  없긴 할텐데 혹시나 몰라 일단 null 체크를 해줌
-        return (authentication as? SecurityUser)?.user ?: throw BaseException(
+        return (authentication as? SecurityUser)?.user?.id ?: throw BaseException(
             ErrorCode.UNAUTHORIZED,
             ErrorCode.UNAUTHORIZED.errorMessage,
         )

--- a/src/main/kotlin/kr/dallyeobom/util/MultipartJackson2HttpMessageConverter.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/MultipartJackson2HttpMessageConverter.kt
@@ -1,0 +1,26 @@
+package kr.dallyeobom.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.MediaType
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter
+import org.springframework.stereotype.Component
+import java.lang.reflect.Type
+
+// application/octet-stream 타입의 멀티파트 요청을 처리하기 위한 Jackson2HttpMessageConverter
+@Component
+class MultipartJackson2HttpMessageConverter(
+    objectMapper: ObjectMapper,
+) : AbstractJackson2HttpMessageConverter(objectMapper, MediaType.APPLICATION_OCTET_STREAM) {
+    override fun canWrite(
+        clazz: Class<*>,
+        mediaType: MediaType?,
+    ): Boolean = false
+
+    override fun canWrite(
+        type: Type?,
+        clazz: Class<*>,
+        mediaType: MediaType?,
+    ): Boolean = false
+
+    override fun canWrite(mediaType: MediaType?): Boolean = false
+}

--- a/src/main/kotlin/kr/dallyeobom/util/validator/MaxFileSizeValidator.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/validator/MaxFileSizeValidator.kt
@@ -1,0 +1,31 @@
+package kr.dallyeobom.util.validator
+
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import org.springframework.web.multipart.MultipartFile
+import kotlin.reflect.KClass
+
+@Constraint(validatedBy = [MaxFileSizeValidator::class])
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MaxFileSize(
+    val max: Int = 1 * 1024 * 1024,
+    val message: String = "파일 사이즈가 초과하였습니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)
+
+class MaxFileSizeValidator : ConstraintValidator<MaxFileSize, MultipartFile?> {
+    private var maxFileSize: Int = 0
+
+    override fun initialize(constraintAnnotation: MaxFileSize) {
+        this.maxFileSize = constraintAnnotation.max
+    }
+
+    override fun isValid(
+        file: MultipartFile?,
+        context: ConstraintValidatorContext,
+    ): Boolean = file == null || file.size <= maxFileSize
+}


### PR DESCRIPTION
### 개요
- 코스 완주 기록을 서버에 저장할수 있도록 하는 API추가

### 변경사항
- 코스 조회 API에서 선택적 파라메터가 스웨거에 필수라고 노출되는 이슈 해결
- 코스 생성 로직 별도의 클래스로 분리
- 코스 완주 기록 생성 API 추가
- 코스 완주 기록 조회 API 추가
- 요청을 보낸 유저를 컨트롤러에서 편하게 가져다 쓸수 있도록 하는 유틸 기능 추가


### 리뷰어에게 하고 싶은 말
- 빠르게 작업해봤습니다~!
