### PR TITLE
DAL-24 유저 랭킹 API 추가

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/DallyeobomApplication.kt
+++ b/src/main/kotlin/kr/dallyeobom/DallyeobomApplication.kt
@@ -5,8 +5,10 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @ConfigurationPropertiesScan
+@EnableScheduling
 @Configuration
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/kotlin/kr/dallyeobom/config/RedissonClientConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/RedissonClientConfig.kt
@@ -1,0 +1,23 @@
+package kr.dallyeobom.config
+
+import kr.dallyeobom.config.properties.RedissonProperties
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.redisson.config.Protocol
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonClientConfig {
+    @Bean
+    fun redissonClient(redissonConfig: RedissonProperties): RedissonClient {
+        val config = Config()
+        config.setProtocol(Protocol.RESP3) // Client side caching을 위한 설정
+        config
+            .useSingleServer()
+            .setAddress("redis://${redissonConfig.host}:${redissonConfig.port}")
+            .setPassword(redissonConfig.password)
+        return Redisson.create(config)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/config/RedissonClientConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/RedissonClientConfig.kt
@@ -18,6 +18,7 @@ class RedissonClientConfig {
             .useSingleServer()
             .setAddress("redis://${redissonConfig.host}:${redissonConfig.port}")
             .setPassword(redissonConfig.password)
+            .setDatabase(redissonConfig.database)
         return Redisson.create(config)
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/config/properties/RedissonProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/RedissonProperties.kt
@@ -1,0 +1,11 @@
+package kr.dallyeobom.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+data class RedissonProperties(
+    val host: String,
+    val port: Int,
+    val password: String,
+    val database: Int,
+)

--- a/src/main/kotlin/kr/dallyeobom/config/swagger/SwaggerTag.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/swagger/SwaggerTag.kt
@@ -6,5 +6,6 @@ object SwaggerTag {
     const val AUTH: String = "B. 인증 API"
     const val COURSE: String = "C. 코스 API"
     const val COURSE_COMPLETION_HISTORY: String = "D. 코스 완료 기록 API"
+    const val USER_RANK: String = "E. 사용자 랭킹 API"
     const val TEMPORAL_AUTH: String = "Y. 임시 인증 API"
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/userRanking/UserRankController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/userRanking/UserRankController.kt
@@ -1,0 +1,19 @@
+package kr.dallyeobom.controller.userRanking
+
+import kr.dallyeobom.controller.userRanking.response.UserRankingResponse
+import kr.dallyeobom.service.UserRankService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/user-rank")
+@RestController
+class UserRankController(
+    private val userRankService: UserRankService,
+) : UserRankControllerSpec {
+    @GetMapping("/{type}")
+    override fun getUserRanking(
+        @PathVariable type: UserRankType,
+    ): UserRankingResponse = userRankService.getUserRanking(type)
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/userRanking/UserRankControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/userRanking/UserRankControllerSpec.kt
@@ -1,0 +1,29 @@
+package kr.dallyeobom.controller.userRanking
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.dallyeobom.config.swagger.SwaggerTag
+import kr.dallyeobom.controller.userRanking.response.UserRankingResponse
+
+@Tag(name = SwaggerTag.USER_RANK)
+interface UserRankControllerSpec {
+    @Operation(
+        summary = "유저 랭킹 조회",
+        description = "유저 랭킹을 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "유저 랭킹 정보"),
+        ],
+    )
+    fun getUserRanking(
+        @Schema(description = "조회하고자 하는 랭킹 타입", example = "DAILY")
+        type: UserRankType,
+    ): UserRankingResponse
+}
+
+enum class UserRankType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/userRanking/response/UserRankingResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/userRanking/response/UserRankingResponse.kt
@@ -1,0 +1,7 @@
+package kr.dallyeobom.controller.userRanking.response
+
+import kr.dallyeobom.dto.UserRank
+
+data class UserRankingResponse(
+    val list: List<UserRank>,
+)

--- a/src/main/kotlin/kr/dallyeobom/dto/UserRank.kt
+++ b/src/main/kotlin/kr/dallyeobom/dto/UserRank.kt
@@ -1,0 +1,10 @@
+package kr.dallyeobom.dto
+
+import java.io.Serializable
+
+data class UserRank(
+    val userId: Long,
+    val nickname: String,
+    val runningLength: Long,
+    val completeCourseCount: Long,
+) : Serializable

--- a/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionHistory.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionHistory.kt
@@ -32,6 +32,8 @@ class CourseCompletionHistory(
     val interval: Duration,
     @Column(columnDefinition = "SDO_GEOMETRY", nullable = false, updatable = false)
     val path: LineString,
+    @Column(nullable = false)
+    val length: Int,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
@@ -1,6 +1,31 @@
 package kr.dallyeobom.repository
 
+import kr.dallyeobom.dto.UserRank
 import kr.dallyeobom.entity.CourseCompletionHistory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
+import java.time.LocalDateTime
 
-interface CourseCompletionHistoryRepository : JpaRepository<CourseCompletionHistory, Long>
+interface CourseCompletionHistoryRepository : JpaRepository<CourseCompletionHistory, Long> {
+    @Query(
+        """
+        SELECT new kr.dallyeobom.dto.UserRank(
+            c.user.id,
+            c.user.nickname,
+            SUM(c.length),
+            COUNT(c)
+        )
+        FROM CourseCompletionHistory c
+        WHERE c.createdDateTime BETWEEN :startDateTime AND :endDateTime
+        GROUP BY c.user.id, c.user.nickname
+        ORDER BY SUM(c.length) DESC
+        LIMIT :limit
+    """,
+    )
+    fun getDateRangeUserRankings(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime = LocalDate.now().atStartOfDay(),
+        limit: Int = 100,
+    ): List<UserRank>
+}

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -15,6 +15,7 @@ import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
 import kr.dallyeobom.repository.UserRepository
 import kr.dallyeobom.util.CourseCreateUtil
+import kr.dallyeobom.util.CourseLengthUtil
 import kr.dallyeobom.util.requireNull
 import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Service
@@ -46,6 +47,7 @@ class CourseCompletionHistoryService(
                     review = request.review,
                     interval = Duration.ofSeconds(request.interval),
                     path = courseCreateUtil.latLngToLineString(request.latLngPath),
+                    length = CourseLengthUtil.calculateTotalDistance(request.latLngPath),
                 ),
             ),
         )

--- a/src/main/kotlin/kr/dallyeobom/service/UserRankService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/UserRankService.kt
@@ -38,6 +38,7 @@ class UserRankService(
             try {
                 setRankData(DAILY_RANKING_KEY, LocalDate.now().minusDays(1))
                 setRankData(WEEKLY_RANKING_KEY, LocalDate.now().minusWeeks(1))
+                // minusMonths(1) 는 28일,30일,31일 이중에 어떤 수치를 가질지 달마다 달라짐 그래서 고정된 30으로 사용
                 setRankData(MONTHLY_RANKING_KEY, LocalDate.now().minusDays(30))
             } finally {
                 lock.unlock()

--- a/src/main/kotlin/kr/dallyeobom/service/UserRankService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/UserRankService.kt
@@ -1,0 +1,82 @@
+package kr.dallyeobom.service
+
+import kr.dallyeobom.controller.userRanking.UserRankType
+import kr.dallyeobom.controller.userRanking.response.UserRankingResponse
+import kr.dallyeobom.dto.UserRank
+import kr.dallyeobom.repository.CourseCompletionHistoryRepository
+import org.redisson.api.RClientSideCaching
+import org.redisson.api.RLock
+import org.redisson.api.RScoredSortedSet
+import org.redisson.api.RedissonClient
+import org.redisson.api.options.ClientSideCachingOptions
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+
+@Service
+class UserRankService(
+    private val redissonClient: RedissonClient,
+    private val courseCompletionHistoryRepository: CourseCompletionHistoryRepository,
+) {
+    private val dailyRankSet by lazy { createRankSet(DAILY_RANKING_KEY) }
+    private val weeklyRankSet by lazy { createRankSet(WEEKLY_RANKING_KEY) }
+    private val monthlyRankSet by lazy { createRankSet(MONTHLY_RANKING_KEY) }
+
+    private fun createRankSet(key: String): RScoredSortedSet<UserRank> {
+        val opts: ClientSideCachingOptions = ClientSideCachingOptions.defaults()
+        val csc: RClientSideCaching = redissonClient.getClientSideCaching(opts)
+        return csc.getScoredSortedSet(key)
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정에 실행
+    fun refreshRank() {
+        val lock: RLock = redissonClient.getLock(LOCK_NAME)
+        if (lock.tryLock(3, 300, TimeUnit.SECONDS)) { // 3초 동안 락을 시도하고, 성공하면 300초 동안 유지
+            try {
+                setRankData(DAILY_RANKING_KEY, LocalDate.now().minusDays(1))
+                setRankData(WEEKLY_RANKING_KEY, LocalDate.now().minusWeeks(1))
+                setRankData(MONTHLY_RANKING_KEY, LocalDate.now().minusDays(30))
+            } finally {
+                lock.unlock()
+            }
+        }
+    }
+
+    private fun setRankData(
+        targetKey: String,
+        startDate: LocalDate,
+    ) {
+        val tmpSet: RScoredSortedSet<UserRank> = redissonClient.getScoredSortedSet(TMP_RANKING_KEY)
+        tmpSet.clear()
+
+        val data: List<UserRank> = courseCompletionHistoryRepository.getDateRangeUserRankings(startDate.atStartOfDay())
+        if (data.isEmpty()) {
+            redissonClient.keys.delete(targetKey)
+        } else {
+            tmpSet.addAll(data.associateWith { it.runningLength.toDouble() }) // ① 임시 키에 새 데이터 적재
+            redissonClient.keys.rename(TMP_RANKING_KEY, targetKey) // RENAME 은 O(1) 원자 연산, 기존 키를 즉시 교체
+        }
+    }
+
+    fun getUserRanking(type: UserRankType): UserRankingResponse =
+        UserRankingResponse(
+            when (type) {
+                UserRankType.DAILY -> dailyRankSet
+                UserRankType.WEEKLY -> weeklyRankSet
+                UserRankType.MONTHLY -> monthlyRankSet
+            }.reversed().toList(),
+        )
+
+    companion object {
+        private const val RANKING_KET_PREFIX = "user:rank:zset"
+        private const val DAILY_RANKING_KEY = "${RANKING_KET_PREFIX}:daily"
+        private const val WEEKLY_RANKING_KEY = "${RANKING_KET_PREFIX}:weekly"
+        private const val MONTHLY_RANKING_KEY = "${RANKING_KET_PREFIX}:monthly"
+        private const val TMP_RANKING_KEY = "${RANKING_KET_PREFIX}:tmp"
+
+        private const val LOCK_NAME = "user:rank:lock"
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/CourseCreateUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseCreateUtil.kt
@@ -14,11 +14,6 @@ import org.springframework.stereotype.Component
 import java.io.ByteArrayInputStream
 import java.util.PriorityQueue
 import kotlin.math.abs
-import kotlin.math.atan2
-import kotlin.math.cos
-import kotlin.math.pow
-import kotlin.math.sin
-import kotlin.math.sqrt
 
 @Component
 class CourseCreateUtil(
@@ -78,7 +73,7 @@ class CourseCreateUtil(
                         overviewImageName,
                         ByteArrayInputStream(imageBytes),
                     ),
-                length = calculateTotalDistance(courseDto.path),
+                length = CourseLengthUtil.calculateTotalDistance(courseDto.path),
                 startPoint = path.startPoint,
                 visibility = courseDto.visibility,
             ),
@@ -153,34 +148,8 @@ class CourseCreateUtil(
         return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) * 0.5)
     }
 
-    private fun calculateTotalDistance(points: List<LatLng>): Int {
-        if (points.size < 2) return 0
-
-        var total = 0.0
-        for (i in 0 until points.lastIndex) {
-            total += haversine(points[i], points[i + 1])
-        }
-        return total.toInt() // 단위: 미터 (m)
-    }
-
-    private fun haversine(
-        p1: LatLng,
-        p2: LatLng,
-    ): Double {
-        val dLat = Math.toRadians(p2.lat - p1.lat)
-        val dLng = Math.toRadians(p2.lng - p1.lng)
-        val a =
-            sin(dLat / 2).pow(2.0) +
-                cos(Math.toRadians(p1.lat)) *
-                cos(Math.toRadians(p2.lat)) *
-                sin(dLng / 2).pow(2.0)
-        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
-        return EARTH_RADIUS * c
-    }
-
     companion object {
         const val WGS84_SRID = 4326 // WGS84 SRID
         private const val MAX_SIMPLIFIED_POINTS = 1000 // 최대 단순화된 포인트 수
-        private const val EARTH_RADIUS = 6371000.0 // 지구 반지름 (미터 단위)
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/util/CourseLengthUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseLengthUtil.kt
@@ -1,0 +1,37 @@
+package kr.dallyeobom.util
+
+import com.google.maps.model.LatLng
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+object CourseLengthUtil {
+    private const val EARTH_RADIUS = 6371000.0 // 지구 반지름 (미터 단위)
+
+    fun calculateTotalDistance(points: List<LatLng>): Int {
+        if (points.size < 2) return 0
+
+        var total = 0.0
+        for (i in 0 until points.lastIndex) {
+            total += haversine(points[i], points[i + 1])
+        }
+        return total.toInt() // 단위: 미터 (m)
+    }
+
+    private fun haversine(
+        p1: LatLng,
+        p2: LatLng,
+    ): Double {
+        val dLat = Math.toRadians(p2.lat - p1.lat)
+        val dLng = Math.toRadians(p2.lng - p1.lng)
+        val a =
+            sin(dLat / 2).pow(2.0) +
+                cos(Math.toRadians(p1.lat)) *
+                cos(Math.toRadians(p2.lat)) *
+                sin(dLng / 2).pow(2.0)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return EARTH_RADIUS * c
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/util/CourseLengthUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/CourseLengthUtil.kt
@@ -13,11 +13,10 @@ object CourseLengthUtil {
     fun calculateTotalDistance(points: List<LatLng>): Int {
         if (points.size < 2) return 0
 
-        var total = 0.0
-        for (i in 0 until points.lastIndex) {
-            total += haversine(points[i], points[i + 1])
-        }
-        return total.toInt() // 단위: 미터 (m)
+        return points
+            .zipWithNext()
+            .sumOf { (p1, p2) -> haversine(p1, p2) }
+            .toInt() // 단위: 미터 (m)
     }
 
     private fun haversine(


### PR DESCRIPTION
### 개요
- 유저들의 달린거리에 따른 일,주,월 별 랭킹이 필요하다

### 변경사항
- 매일 0시 0분에 도는 스케쥴러 추가
- Client side caching을 적극 확용하여 MSA 서버들이 다 최신화된 값을 가지도록 보장


### 리뷰어에게 하고 싶은 말
- 데이터가 많이쌓여야 제대로 되는지 확인이 되는데 일단 되는건 확인했습니다! ㅎㅎ
