### PR TITLE
DAL-26 유저의 코스 완료 기록 리스트 조회 API 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,12 @@ dependencies {
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1") // 3.3버전에 이슈가 있어서 올리면 안됨
     // implementation("org.hibernate.search:hibernate-search-backend-elasticsearch:7.2.3.Final") // OpenSearch를 사용하게되면 주석 해제
 
+    // Dynamic Query
+    implementation("com.linecorp.kotlin-jdsl:jpql-dsl:3.5.5")
+    implementation("com.linecorp.kotlin-jdsl:jpql-render:3.5.5")
+    implementation("com.linecorp.kotlin-jdsl:spring-data-jpa-support:3.5.5")
+    implementation("com.linecorp.kotlin-jdsl:hibernate-kotlin-jdsl-jakarta:2.2.1.RELEASE")
+
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.6")

--- a/src/main/kotlin/kr/dallyeobom/controller/common/request/SliceRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/common/request/SliceRequest.kt
@@ -1,0 +1,21 @@
+package kr.dallyeobom.controller.common.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Positive
+
+data class SliceRequest(
+    @field:Positive(message = "마지막 조회 ID는 양수여야 합니다.")
+    @field:Schema(
+        description = "받은 데이터의 마지막 ID - 값이 없으면 처음부터",
+        example = "10",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val lastId: Long?,
+    @field:Positive(message = "조회하고자 리스트의 크기는 양수여야 합니다.")
+    @field:Schema(
+        description = "조회하고자 하는 리스트 크기 - 값이 없으면 10",
+        example = "10",
+        requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+    )
+    val size: Int = 10,
+)

--- a/src/main/kotlin/kr/dallyeobom/controller/common/response/SliceResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/common/response/SliceResponse.kt
@@ -1,0 +1,16 @@
+package kr.dallyeobom.controller.common.response
+
+import org.springframework.data.domain.Slice
+
+class SliceResponse<R>(
+    val items: List<R>,
+    val lastId: Long? = null,
+    val hasNext: Boolean,
+) {
+    companion object {
+        fun <R> from(
+            slice: Slice<R>,
+            lastId: Long?,
+        ) = SliceResponse(slice.content, lastId, slice.hasNext())
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -1,9 +1,12 @@
 package kr.dallyeobom.controller.courseCompletionHistory
 
 import jakarta.validation.constraints.Positive
+import kr.dallyeobom.controller.common.request.SliceRequest
+import kr.dallyeobom.controller.common.response.SliceResponse
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryResponse
 import kr.dallyeobom.service.CourseCompletionHistoryService
 import kr.dallyeobom.util.LoginUserId
 import org.springframework.http.HttpStatus
@@ -42,4 +45,12 @@ class CourseCompletionHistoryController(
         @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
         id: Long,
     ): CourseCompletionHistoryDetailResponse = courseCompletionHistoryService.getCourseCompletionHistoryDetail(id)
+
+    @GetMapping("/user/{userId}")
+    override fun getCourseCompletionHistoryListByUserId(
+        @PathVariable
+        userId: Long,
+        sliceRequest: SliceRequest,
+    ): SliceResponse<CourseCompletionHistoryResponse> =
+        courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(userId, sliceRequest)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -8,10 +8,14 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 import kr.dallyeobom.config.swagger.SwaggerTag
+import kr.dallyeobom.controller.common.request.SliceRequest
+import kr.dallyeobom.controller.common.response.SliceResponse
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
+import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryResponse
 import kr.dallyeobom.util.validator.MaxFileSize
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.multipart.MultipartFile
 
@@ -70,4 +74,20 @@ interface CourseCompletionHistoryControllerSpec {
         @Schema(description = "상세조회 하고자 하는 완주 기록의 ID", example = "1")
         id: Long,
     ): CourseCompletionHistoryDetailResponse
+
+    @Operation(
+        summary = "특정 유저의 코스 완주 기록 리스트 조회",
+        description = "특정 유저의 코스 완주 기록 리스트를 조회합니다. 서버 조회 성능을 위해 무한스크롤 방식으로 구현되었습니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "코스 완주 기록 정보 리스트"),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 유저가 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun getCourseCompletionHistoryListByUserId(
+        @Positive(message = "유저 ID는 양수여야 합니다.")
+        @Schema(description = "조회하고자 하는 유저의 ID", example = "1")
+        userId: Long,
+        @Validated
+        @ParameterObject sliceRequest: SliceRequest,
+    ): SliceResponse<CourseCompletionHistoryResponse>
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
@@ -20,9 +20,14 @@ class CourseCompletionHistoryDetailResponse(
         example = "[{\"latitude\": 37.5665, \"longitude\": 126.978}, {\"latitude\": 37.567, \"longitude\": 126.979}]",
     )
     val path: List<LatLngDto>,
+    @Schema(description = "코스 완주 인증샷들", example = "[\"https://example.com/image.jpg\"]")
+    val completionImages: List<String>,
 ) {
     companion object {
-        fun from(courseCompletionHistory: CourseCompletionHistory): CourseCompletionHistoryDetailResponse =
+        fun from(
+            courseCompletionHistory: CourseCompletionHistory,
+            imageUrls: List<String>,
+        ): CourseCompletionHistoryDetailResponse =
             CourseCompletionHistoryDetailResponse(
                 id = courseCompletionHistory.id,
                 courseId = courseCompletionHistory.course?.id,
@@ -30,6 +35,7 @@ class CourseCompletionHistoryDetailResponse(
                 review = courseCompletionHistory.review,
                 interval = courseCompletionHistory.interval.toSeconds(),
                 path = courseCompletionHistory.path.coordinates.map { LatLngDto(it.x, it.y) },
+                completionImages = imageUrls,
             )
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
@@ -1,0 +1,31 @@
+package kr.dallyeobom.controller.courseCompletionHistory.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.entity.CourseCompletionHistory
+
+data class CourseCompletionHistoryResponse(
+    @Schema(description = "코스 완주 기록 ID", example = "1")
+    val id: Long,
+    @Schema(description = "연결된 코스 ID", example = "1")
+    val courseId: Long?,
+    @Schema(description = "걸린시간 (초)", example = "3600")
+    val interval: Long,
+    @Schema(description = "거리 (미터)", example = "5000")
+    val length: Int,
+    @Schema(description = "코스 완주 인증샷", example = "\"https://example.com/image.jpg\"")
+    val completionImage: String,
+) {
+    companion object {
+        fun from(
+            item: CourseCompletionHistory,
+            imageUrl: String,
+        ): CourseCompletionHistoryResponse =
+            CourseCompletionHistoryResponse(
+                id = item.id,
+                courseId = item.course?.takeIf { it.deletedDateTime == null }?.id,
+                interval = item.interval.toSeconds(),
+                length = item.length,
+                completionImage = imageUrl,
+            )
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionHistoryRepository.kt
@@ -1,31 +1,73 @@
 package kr.dallyeobom.repository
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import kr.dallyeobom.controller.common.request.SliceRequest
 import kr.dallyeobom.dto.UserRank
 import kr.dallyeobom.entity.CourseCompletionHistory
+import kr.dallyeobom.entity.User
+import kr.dallyeobom.util.getAll
+import kr.dallyeobom.util.getSlice
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-interface CourseCompletionHistoryRepository : JpaRepository<CourseCompletionHistory, Long> {
-    @Query(
-        """
-        SELECT new kr.dallyeobom.dto.UserRank(
-            c.user.id,
-            c.user.nickname,
-            SUM(c.length),
-            COUNT(c)
-        )
-        FROM CourseCompletionHistory c
-        WHERE c.createdDateTime BETWEEN :startDateTime AND :endDateTime
-        GROUP BY c.user.id, c.user.nickname
-        ORDER BY SUM(c.length) DESC
-        LIMIT :limit
-    """,
-    )
+interface CourseCompletionHistoryRepository :
+    JpaRepository<CourseCompletionHistory, Long>,
+    CustomCourseCompletionHistoryRepository
+
+interface CustomCourseCompletionHistoryRepository {
     fun getDateRangeUserRankings(
         startDateTime: LocalDateTime,
         endDateTime: LocalDateTime = LocalDate.now().atStartOfDay(),
         limit: Int = 100,
     ): List<UserRank>
+
+    fun findAllByUserOrderByCreatedDateTimeDesc(
+        user: User,
+        sliceRequest: SliceRequest,
+    ): Slice<CourseCompletionHistory>
+}
+
+class CustomCourseCompletionHistoryRepositoryImpl(
+    private val kotlinJdslJpqlExecutor: KotlinJdslJpqlExecutor,
+) : CustomCourseCompletionHistoryRepository {
+    override fun getDateRangeUserRankings(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
+        limit: Int,
+    ) = kotlinJdslJpqlExecutor.getAll(limit) {
+        val courseCompletionHistoryEntity = entity(CourseCompletionHistory::class)
+        selectNew<UserRank>(
+            path(User::id),
+            path(User::nickname),
+            sum(CourseCompletionHistory::length),
+            count(courseCompletionHistoryEntity),
+        ).from(
+            courseCompletionHistoryEntity,
+            join(CourseCompletionHistory::user),
+        ).where(
+            path(CourseCompletionHistory::createdDateTime).between(startDateTime, endDateTime),
+        ).groupBy(
+            // Id를 기준으로 그룹을 잡아도 되지만 ANSI SQL 표준에 따라 select 절에 있는 컬럼을 모두 group by에 넣어야함
+            path(User::id),
+            path(User::nickname),
+        ).orderBy(
+            sum(CourseCompletionHistory::length).desc(),
+        )
+    }
+
+    override fun findAllByUserOrderByCreatedDateTimeDesc(
+        user: User,
+        sliceRequest: SliceRequest,
+    ) = kotlinJdslJpqlExecutor.getSlice(Pageable.ofSize(sliceRequest.size)) {
+        val entity = entity(CourseCompletionHistory::class)
+        select(entity)
+            .from(entity)
+            .whereAnd(
+                path(CourseCompletionHistory::user).eq(user),
+                sliceRequest.lastId?.let { path(CourseCompletionHistory::id).lt(it) },
+            ).orderBy(path(CourseCompletionHistory::createdDateTime).desc())
+    }
 }

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionImageRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseCompletionImageRepository.kt
@@ -1,6 +1,11 @@
 package kr.dallyeobom.repository
 
+import kr.dallyeobom.entity.CourseCompletionHistory
 import kr.dallyeobom.entity.CourseCompletionImage
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CourseCompletionImageRepository : JpaRepository<CourseCompletionImage, Long>
+interface CourseCompletionImageRepository : JpaRepository<CourseCompletionImage, Long> {
+    fun findAllByCompletion(completion: CourseCompletionHistory): List<CourseCompletionImage>
+
+    fun findAllByCompletionIn(completions: List<CourseCompletionHistory>): List<CourseCompletionImage>
+}

--- a/src/main/kotlin/kr/dallyeobom/util/KotlinJDSLUtil.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/KotlinJDSLUtil.kt
@@ -1,0 +1,39 @@
+package kr.dallyeobom.util
+
+import com.linecorp.kotlinjdsl.dsl.jpql.Jpql
+import com.linecorp.kotlinjdsl.querymodel.jpql.JpqlQueryable
+import com.linecorp.kotlinjdsl.querymodel.jpql.select.SelectQuery
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+// findSlice의 경우 Slice<T?>를 반환하는데 순수하게 엔티티만 조회하는경우 null이 반환될 수 없으므로 Slice<T>로 강제 캐스팅해도 안전합니다.
+// 대신 nullable 가능성이 있는 단순 컬럼 조회시에는 Slice<T?>로 반환되므로 그땐 getSlice가 아닌 findSlice를 사용해야 합니다.
+// 참고 : https://github.com/line/kotlin-jdsl/issues/608
+// Slice Page 조회시 Fetch조인을 사용하면 항상 에러가 발생합니다
+// 참고 : https://github.com/line/kotlin-jdsl/issues/176#issuecomment-1404862616
+fun <T : Any> KotlinJdslJpqlExecutor.getSlice(
+    pageable: Pageable,
+    init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+): Slice<T> =
+    findSlice(
+        pageable,
+        init,
+    ) as Slice<T>
+
+fun <T : Any> KotlinJdslJpqlExecutor.getPage(
+    pageable: Pageable,
+    init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+): Page<T> =
+    findPage(
+        pageable,
+        init,
+    ) as Page<T>
+
+fun <T : Any> KotlinJdslJpqlExecutor.getAll(
+    limit: Int? = null,
+    init: Jpql.() -> JpqlQueryable<SelectQuery<T>>,
+): List<T> = findAll(null, limit, init) as List<T>
+
+fun <T : Any> KotlinJdslJpqlExecutor.getOne(init: Jpql.() -> JpqlQueryable<SelectQuery<T>>): T? = findAll(null, 1, init).firstOrNull()


### PR DESCRIPTION
### 개요
- userId를 넣으면 해당 유저가 달린 코스 완료 기록을 반환하는 API가 필요하다

### 변경사항
- 코스 완주 기록 조회 API추가
- 복잡하거나 동적인 조건이 필요한 쿼리를 위한 Kotlin JDSL 도입
- 서버의 조회 성능을 위한 Slice조회(무한 스크롤 조회) 기초 도입


### 리뷰어에게 하고 싶은 말
- 이번 작업을 하면서 저희 코드에 필요한게 많아서 많은게 추가되었는데 천천히 확인해보시고 리뷰 부탁드립니다 ㅎㅎ
