### PR TITLE
DAL-28 코스 등록 및 수정 API 추가

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
@@ -1,16 +1,22 @@
 package kr.dallyeobom.controller.course
 
-import jakarta.validation.constraints.Positive
+import kr.dallyeobom.controller.course.request.CourseUpdateRequest
 import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
 import kr.dallyeobom.service.CourseService
+import kr.dallyeobom.util.LoginUserId
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.NO_CONTENT
+import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/api/v1/course")
@@ -32,7 +38,19 @@ class CourseController(
     @GetMapping("/{id}")
     override fun getCourseDetail(
         @PathVariable
-        @Positive(message = "코스 ID는 양수여야 합니다.")
         id: Long,
     ): CourseDetailResponse = courseService.getCourseDetail(id)
+
+    @ResponseStatus(NO_CONTENT)
+    @PatchMapping("/{id}", consumes = [MULTIPART_FORM_DATA_VALUE])
+    override fun updateCourse(
+        @LoginUserId
+        userId: Long,
+        @PathVariable
+        id: Long,
+        @RequestPart
+        request: CourseUpdateRequest,
+        @RequestPart(required = false)
+        courseImage: MultipartFile?,
+    ) = courseService.updateCourse(userId, id, request, courseImage)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
@@ -7,11 +7,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Positive
 import kr.dallyeobom.config.swagger.SwaggerTag
+import kr.dallyeobom.controller.course.request.CourseUpdateRequest
 import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
+import kr.dallyeobom.util.validator.MaxFileSize
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = SwaggerTag.COURSE)
 interface CourseControllerSpec {
@@ -60,4 +63,35 @@ interface CourseControllerSpec {
         @Schema(description = "상세조회 하고자 하는 코스의 ID", example = "1")
         id: Long,
     ): CourseDetailResponse
+
+    @Operation(
+        summary = "코스 정보 수정",
+        description = "본인이 올린 코스의 정보를 수정합니다. 수정할 데이터만 값을 보내면 되며 데이터를 안보내면 기존값 유지",
+        responses = [
+            ApiResponse(responseCode = "204", description = "코스 정보 수정 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = """
+        잘못된 요청:
+        • 코스 ID가 양수가 아님  
+        • 코스 설명이 1자 미만이거나 500자를 초과함
+        • 코스명이 1자 미만이거나 30자를 초과함
+        • 파일 사이즈가 1MB를 초과함
+      """,
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "403", description = "유저가 생성한 코스가 아님", content = arrayOf(Content())),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 코스가 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun updateCourse(
+        userId: Long,
+        @Positive(message = "코스 ID는 양수여야 합니다.")
+        @Schema(description = "수정하고자 하는 코스의 ID", example = "1")
+        id: Long,
+        request: CourseUpdateRequest,
+        @MaxFileSize
+        @Schema(description = "코스 대표 이미지", required = false)
+        courseImage: MultipartFile?,
+    )
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/request/CourseUpdateRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/request/CourseUpdateRequest.kt
@@ -1,0 +1,19 @@
+package kr.dallyeobom.controller.course.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.entity.CourseLevel
+import kr.dallyeobom.entity.CourseVisibility
+import org.hibernate.validator.constraints.Length
+
+data class CourseUpdateRequest(
+    @field:Schema(description = "코스 설명", example = "서울 한강을 따라 자전거를 탈 수 있는 코스입니다.")
+    @field:Length(min = 1, max = 500, message = "코스 설명은 최소 1자, 최대 500자까지 입력 가능합니다.")
+    val description: String?,
+    @field:Schema(description = "코스명", example = "서울 한강 러닝 코스")
+    @field:Length(min = 1, max = 30, message = "코스명은 최소 1자, 최대 30자까지 입력 가능합니다.")
+    val name: String?,
+    @field:Schema(description = "코스 난이도", example = "LOW")
+    val courseLevel: CourseLevel?,
+    @field:Schema(description = "코스 공개 설정", example = "PUBLIC")
+    val courseVisibility: CourseVisibility? = null,
+)

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -2,6 +2,7 @@ package kr.dallyeobom.controller.courseCompletionHistory
 
 import jakarta.validation.constraints.Positive
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.service.CourseCompletionHistoryService
@@ -42,4 +43,17 @@ class CourseCompletionHistoryController(
         @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
         id: Long,
     ): CourseCompletionHistoryDetailResponse = courseCompletionHistoryService.getCourseCompletionHistoryDetail(id)
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{id}/create-course", consumes = [MULTIPART_FORM_DATA_VALUE])
+    override fun createCourseFromCompletionHistory(
+        @LoginUserId
+        userId: Long,
+        @PathVariable
+        id: Long,
+        @RequestPart
+        request: CourseCreateRequest,
+        @RequestPart(required = false)
+        courseImage: MultipartFile?,
+    ) = courseCompletionHistoryService.createCourseFromCompletionHistory(userId, id, request, courseImage)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
 import kr.dallyeobom.config.swagger.SwaggerTag
 import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCompletionCreateRequest
+import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCreateRequest
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.util.validator.MaxFileSize
@@ -70,4 +71,36 @@ interface CourseCompletionHistoryControllerSpec {
         @Schema(description = "상세조회 하고자 하는 완주 기록의 ID", example = "1")
         id: Long,
     ): CourseCompletionHistoryDetailResponse
+
+    @Operation(
+        summary = "코스 완주기록을 기반으로 코스 생성",
+        description = "코스 완주기록 ID를 입력받아 해당 기록을 기반으로 코스를 생성합니다.",
+        responses = [
+            ApiResponse(responseCode = "204", description = "코스 완주 기록 상세 정보"),
+            ApiResponse(
+                responseCode = "400",
+                description = """
+        잘못된 요청:
+        • 완주기록 ID가 양수가 아님  
+        • 코스 설명이 1자 미만이거나 500자를 초과함
+        • 코스명이 1자 미만이거나 30자를 초과함
+        • 파일 사이즈가 1MB를 초과함
+        • 이미 해당 완주 기록으로 생성된 코스가 존재함
+      """,
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "403", description = "유저가 생성한 완주기록이 아님", content = arrayOf(Content())),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 기록 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun createCourseFromCompletionHistory(
+        userId: Long,
+        @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
+        @Schema(description = "생성하고자 하는 코스의 완주 기록 ID", example = "1")
+        id: Long,
+        @Validated request: CourseCreateRequest,
+        @MaxFileSize
+        @Schema(description = "코스 대표사진 - 코스 등록시에만 사용하며 없어도됨, 사진의 최대 크기는 1MB")
+        courseImage: MultipartFile?,
+    )
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -76,7 +76,7 @@ interface CourseCompletionHistoryControllerSpec {
         summary = "코스 완주기록을 기반으로 코스 생성",
         description = "코스 완주기록 ID를 입력받아 해당 기록을 기반으로 코스를 생성합니다.",
         responses = [
-            ApiResponse(responseCode = "204", description = "코스 완주 기록 상세 정보"),
+            ApiResponse(responseCode = "201", description = "코스 생성 성공"),
             ApiResponse(
                 responseCode = "400",
                 description = """

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCreateRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCreateRequest.kt
@@ -1,0 +1,16 @@
+package kr.dallyeobom.controller.courseCompletionHistory.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.entity.CourseLevel
+import org.hibernate.validator.constraints.Length
+
+data class CourseCreateRequest(
+    @field:Schema(description = "코스 설명", example = "서울 한강을 따라 자전거를 탈 수 있는 코스입니다.")
+    @field:Length(min = 1, max = 500, message = "코스 설명은 최소 1자, 최대 500자까지 입력 가능합니다.")
+    val description: String,
+    @field:Schema(description = "코스명", example = "서울 한강 러닝 코스")
+    @field:Length(min = 1, max = 30, message = "코스명은 최소 1자, 최대 30자까지 입력 가능합니다.")
+    val name: String,
+    @field:Schema(description = "코스 난이도", example = "LOW")
+    val courseLevel: CourseLevel,
+)

--- a/src/main/kotlin/kr/dallyeobom/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/BaseTimeEntity.kt
@@ -31,7 +31,6 @@ abstract class BaseModifiableEntity : BaseTimeEntity() {
 * Soft Delete를 지원해야하는 엔티티가 상속받는 클래스
 * 해당 클래스를 상속받는 엔티티들은 아래와 같은 어노테이션 2개를 붙혀서 사용해야한다
 * @SQLDelete(sql = "UPDATE <TABLE_NAME> SET deleted_datetime = current_timestamp WHERE id = ?")
-* @SQLRestriction("deleted_datetime IS NULL")
 * */
 @MappedSuperclass
 abstract class BaseSoftDeletableEntity : BaseModifiableEntity() {

--- a/src/main/kotlin/kr/dallyeobom/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/BaseTimeEntity.kt
@@ -38,4 +38,12 @@ abstract class BaseSoftDeletableEntity : BaseModifiableEntity() {
     @Column(name = "deleted_datetime", nullable = true)
     var deletedDateTime: LocalDateTime? = null
         protected set
+
+    fun delete() {
+        deletedDateTime = LocalDateTime.now()
+    }
+
+    fun restore() {
+        deletedDateTime = null
+    }
 }

--- a/src/main/kotlin/kr/dallyeobom/entity/Course.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/Course.kt
@@ -9,14 +9,12 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.SQLDelete
-import org.hibernate.annotations.SQLRestriction
 import org.locationtech.jts.geom.LineString
 import org.locationtech.jts.geom.Point
 
 @Entity
 @Table
 @SQLDelete(sql = "UPDATE course SET deleted_datetime = current_timestamp WHERE id = ?")
-@SQLRestriction("deleted_datetime IS NULL")
 class Course(
     @Column(nullable = false, length = 30)
     var name: String,

--- a/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionHistory.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/CourseCompletionHistory.kt
@@ -21,7 +21,7 @@ class CourseCompletionHistory(
     // 유저가 코스를 선택하고 달린 경우에만 코스를 연결
     @ManyToOne
     @JoinColumn
-    val course: Course?,
+    var course: Course?,
     @ManyToOne
     @JoinColumn(nullable = false, updatable = false)
     val user: User,

--- a/src/main/kotlin/kr/dallyeobom/exception/AlreadyCreatedCourseException.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/AlreadyCreatedCourseException.kt
@@ -1,0 +1,3 @@
+package kr.dallyeobom.exception
+
+class AlreadyCreatedCourseException : BaseException(ErrorCode.ALREADY_CREATED_COURSE, ErrorCode.ALREADY_CREATED_COURSE.errorMessage)

--- a/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
@@ -16,6 +16,7 @@ enum class ErrorCode(
 
     // FORBIDDEN는 40300부터 시작
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "접근 권한이 없습니다."),
+    NOT_COURSE_CREATOR(HttpStatus.FORBIDDEN, 40301, "해당 코스의 생성자가 아닙니다."),
 
     // 리소스 NOT FOUND는 40400부터 시작
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "해당 유저를 찾을 수 없습니다."),

--- a/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
@@ -10,6 +10,7 @@ enum class ErrorCode(
     // 요청을 잘못했을 때는 40000부터 시작
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 40000, "잘못된 요청입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, 40001, "유효하지 않은 RefreshToken 입니다."),
+    ALREADY_CREATED_COURSE(HttpStatus.BAD_REQUEST, 40002, "이미 생성된 코스입니다."),
 
     // UNAUTHORIZED는 40100부터 시작
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),
@@ -17,6 +18,7 @@ enum class ErrorCode(
     // FORBIDDEN는 40300부터 시작
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "접근 권한이 없습니다."),
     NOT_COURSE_CREATOR(HttpStatus.FORBIDDEN, 40301, "해당 코스의 생성자가 아닙니다."),
+    NOT_COURSE_COMPLETION_HISTORY_CREATOR(HttpStatus.FORBIDDEN, 40302, "해당 완주 기록의 생성자가 아닙니다."),
 
     // 리소스 NOT FOUND는 40400부터 시작
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "해당 유저를 찾을 수 없습니다."),

--- a/src/main/kotlin/kr/dallyeobom/exception/NotCourseCompletionHistoryCreatorException.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/NotCourseCompletionHistoryCreatorException.kt
@@ -1,0 +1,7 @@
+package kr.dallyeobom.exception
+
+class NotCourseCompletionHistoryCreatorException :
+    BaseException(
+        ErrorCode.NOT_COURSE_COMPLETION_HISTORY_CREATOR,
+        ErrorCode.NOT_COURSE_COMPLETION_HISTORY_CREATOR.errorMessage,
+    )

--- a/src/main/kotlin/kr/dallyeobom/exception/NotCourseCreatorException.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/NotCourseCreatorException.kt
@@ -1,0 +1,7 @@
+package kr.dallyeobom.exception
+
+class NotCourseCreatorException :
+    BaseException(
+        ErrorCode.NOT_COURSE_CREATOR,
+        ErrorCode.NOT_COURSE_CREATOR.errorMessage,
+    )

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
@@ -20,7 +20,7 @@ interface CourseRepository : JpaRepository<Course, Long> {
             ),
             'sdo_num_res=' || :maxCount || ' distance=' || :radius || ' unit=meter',
             1
-        ) = 'TRUE'
+        ) = 'TRUE' and DELETED_DATETIME is NULL
         ORDER BY SDO_NN_DISTANCE(1)
         """,
         nativeQuery = true,

--- a/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/ObjectStorageRepository.kt
@@ -2,8 +2,11 @@ package kr.dallyeobom.repository
 
 import io.awspring.cloud.s3.S3Template
 import kr.dallyeobom.config.properties.ObjectStorageProperties
+import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Repository
+import org.springframework.web.multipart.MultipartFile
 import java.io.InputStream
+import java.util.Locale
 import java.util.UUID
 
 @Repository
@@ -18,6 +21,18 @@ class ObjectStorageRepository(
     ): String {
         val result = s3Template.upload(objectStorageProperties.bucket, path + key, stream)
         return result.filename
+    }
+
+    fun upload(
+        path: String,
+        file: MultipartFile,
+    ): String {
+        requireNotNull(file.originalFilename) { "파일의 원본 파일명이 필요합니다." }
+        val extension =
+            FilenameUtils
+                .getExtension(file.originalFilename)
+                .lowercase(Locale.getDefault())
+        return upload(path, generateFileName(extension), file.inputStream)
     }
 
     fun getDownloadUrl(key: String): String = "${objectStorageProperties.cdnUrl}/$key"

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -24,12 +24,10 @@ import kr.dallyeobom.repository.UserRepository
 import kr.dallyeobom.util.CourseCreateUtil
 import kr.dallyeobom.util.CourseLengthUtil
 import kr.dallyeobom.util.requireNull
-import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.time.Duration
-import java.util.Locale
 import kotlin.jvm.optionals.getOrNull
 
 @Service
@@ -158,12 +156,7 @@ class CourseCompletionHistoryService(
         requireNotNull(imageFile.originalFilename) { "코스 이미지의 원본 파일명이 필요합니다." }
         return objectStorageRepository.upload(
             path,
-            ObjectStorageRepository.generateFileName(
-                FilenameUtils
-                    .getExtension(imageFile.originalFilename)
-                    .lowercase(Locale.getDefault()),
-            ),
-            imageFile.inputStream,
+            imageFile,
         )
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -19,7 +19,6 @@ import kr.dallyeobom.exception.NotCourseCreatorException
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
 import kr.dallyeobom.util.CourseCreateUtil
-import org.apache.commons.io.FilenameUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -123,15 +122,11 @@ class CourseService(
         }
 
         if (imageFile != null) {
+            course.image?.let { objectStorageRepository.delete(it) }
             course.image =
                 objectStorageRepository.upload(
                     ObjectStorageRepository.COURSE_IMAGE_PATH,
-                    ObjectStorageRepository.generateFileName(
-                        FilenameUtils
-                            .getExtension(imageFile.originalFilename)
-                            .lowercase(Locale.getDefault()),
-                    ),
-                    imageFile.inputStream,
+                    imageFile,
                 )
         }
     }


### PR DESCRIPTION
### 개요
- 코스 완주 기록을 등록할 당시에 코스를 등록하지 않아도 추후에 등록할수 있어야한다
- 등록한 코스의 정보를 수정하거나 코스를 private로 바꿀수 있어야한다

### 변경사항
- 코스 추가 및 수정 API 추가


### 리뷰어에게 하고 싶은 말
- 아직 기획이 확실친 않지만 추가할 계획이라고 하셨던것 같아서 작업했습니다~!
