### PR TITLE
DAL-33 완주 기록 삭제 API 추가

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -55,4 +55,12 @@ class CourseCompletionHistoryController(
         sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse> =
         courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(userId, sliceRequest)
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/{id}/delete")
+    override fun deleteCourseCompletionHistory(
+        @LoginUserId
+        userId: Long,
+        @PathVariable id: Long,
+    ) = courseCompletionHistoryService.deleteCourseCompletionHistory(userId, id)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -91,4 +91,29 @@ interface CourseCompletionHistoryControllerSpec {
         @Validated
         @ParameterObject sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse>
+
+    @Operation(
+        summary = "코스 완주 기록 삭제",
+        description = "코스 완주 기록 ID를 입력받아 해당 기록을 삭제합니다.",
+        responses = [
+            ApiResponse(responseCode = "204", description = "코스 완주 기록 삭제 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 - 코스 완주 기록 ID가 양수가 아님",
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "유저가 생성한 코스 완주 기록이 아님",
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "404", description = "존재하지 않는 코스 완주 기록 ID를 입력한 경우", content = arrayOf(Content())),
+        ],
+    )
+    fun deleteCourseCompletionHistory(
+        userId: Long,
+        @Positive(message = "코스 완주 기록 ID는 양수여야 합니다.")
+        @Schema(description = "삭제하고자 하는 코스 완주 기록의 ID", example = "1")
+        id: Long,
+    )
 }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -160,4 +160,30 @@ class CourseCompletionHistoryService(
             imageFile.inputStream,
         )
     }
+
+    @Transactional
+    fun deleteCourseCompletionHistory(
+        userId: Long,
+        id: Long,
+    ) {
+        val courseCompletionHistory =
+            courseCompletionHistoryRepository.findById(id).orElseThrow { CourseCompletionHistoryNotFoundException() }
+
+        if (courseCompletionHistory.user.id != userId) {
+            throw NotCourseCompletionHistoryCreatorException()
+        }
+
+        val images = courseCompletionImageRepository.findAllByCompletion(courseCompletionHistory)
+
+        images.forEach { image ->
+            objectStorageRepository.delete(image.image)
+            courseCompletionImageRepository.delete(image)
+        }
+
+        courseCompletionHistoryRepository.delete(courseCompletionHistory)
+        val course = courseCompletionHistory.course
+        if (course != null && course.creatorId == userId && course.deletedDateTime == null) {
+            courseRepository.deleteById(course.id)
+        }
+    }
 }


### PR DESCRIPTION
### 개요
- 완주 기록을 삭제할수도 있어야한다

### 변경사항
- 완주기록 삭제 API 추가


### 리뷰어에게 하고 싶은 말
- DAL-26이랑 DAL-28에 각각 작업된 코드들이 필요해서 요 브랜치가 독립적으로 돌아가진 않습니다 ㅠㅠ
- 나중에 PR들 정리된뒤 실행 확인 부탁드려요..!