### PR TITLE
DAL-40 주변 코스 조회 API를 인기순으로 정렬

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
@@ -1,34 +1,57 @@
 package kr.dallyeobom.repository
 
+import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
 import kr.dallyeobom.entity.Course
+import kr.dallyeobom.entity.CourseCompletionHistory
+import kr.dallyeobom.util.getAll
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface CourseRepository : JpaRepository<Course, Long> {
-    @Query(
-        """
-        SELECT c.*
-        FROM COURSE c
-        WHERE SDO_NN(
-            c.start_point,
-            SDO_GEOMETRY(
-                  2001, 4326,
-                  SDO_POINT_TYPE(:latitude, :longitude,  NULL),
-                  NULL, NULL
-            ),
-            'sdo_num_res=' || :maxCount || ' distance=' || :radius || ' unit=meter',
-            1
-        ) = 'TRUE' and DELETED_DATETIME is NULL
-        ORDER BY SDO_NN_DISTANCE(1)
-        """,
-        nativeQuery = true,
-    )
+interface CourseRepository :
+    JpaRepository<Course, Long>,
+    CustomCourseRepository
+
+interface CustomCourseRepository {
     fun findNearByCourseByLocation(
         longitude: Double,
         latitude: Double,
         radius: Int,
         maxCount: Int,
     ): List<Course>
+}
+
+class CustomCourseRepositoryImpl(
+    private val kotlinJdslJpqlExecutor: KotlinJdslJpqlExecutor,
+) : CustomCourseRepository {
+    override fun findNearByCourseByLocation(
+        longitude: Double,
+        latitude: Double,
+        radius: Int,
+        maxCount: Int,
+    ): List<Course> =
+        kotlinJdslJpqlExecutor.getAll(maxCount) {
+            val entity = entity(Course::class, "c1")
+            selectDistinct(entity)
+                .from(
+                    entity,
+                ).whereAnd(
+                    customExpression(
+                        String::class,
+                        "SDO_NN({0}, SDO_GEOMETRY(2001, 4326, SDO_POINT_TYPE({1}, {2}, NULL), NULL, NULL), 'distance=' || {3} || ' unit=meter', 1)",
+                        entity(Course::startPoint),
+                        latitude,
+                        longitude,
+                        radius,
+                    ).eq("TRUE"),
+                    entity(Course::deletedDateTime).isNull(),
+                ).orderBy(
+                    // 가장 많이 완주된 코스가 먼저 나오도록
+                    select(count(CourseCompletionHistory::id))
+                        .from(entity(CourseCompletionHistory::class))
+                        .where(path(CourseCompletionHistory::course).eq(entity))
+                        .asSubquery()
+                        .desc(),
+                )
+        }
 }


### PR DESCRIPTION
### 개요
- 주변 코스 조회시 거리순이 아니라 인기순으로 반환해야 한다

### 변경사항
- JPQL 쿼리를 JDSL로 옮기고 정렬 조건 수정


### 리뷰어에게 하고 싶은 말
- 이전에는 인기순 정렬인지 모르고 거리순으로 작업했었던것 같네요 ㅋㅋㅋㅋ