### PR TITLE
DAL-47 푸시 기능 기초 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,9 @@ dependencies {
     // Map
     implementation("com.google.maps:google-maps-services:2.2.0")
 
+    // Firebase
+    implementation("com.google.firebase:firebase-admin:9.5.0")
+
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/kr/dallyeobom/config/FirebaseConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/FirebaseConfig.kt
@@ -16,15 +16,14 @@ class FirebaseConfig(
     fun init() {
         if (FirebaseApp.getApps().isNotEmpty()) return
 
-        val credentials =
-            ByteArrayInputStream(firebaseProperties.firebaseServiceAccountJson.toByteArray())
+        ByteArrayInputStream(firebaseProperties.firebaseServiceAccountJson.toByteArray()).use { credentials ->
+            val options =
+                FirebaseOptions
+                    .builder()
+                    .setCredentials(GoogleCredentials.fromStream(credentials))
+                    .build()
 
-        val options =
-            FirebaseOptions
-                .builder()
-                .setCredentials(GoogleCredentials.fromStream(credentials))
-                .build()
-
-        FirebaseApp.initializeApp(options)
+            FirebaseApp.initializeApp(options)
+        }
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/config/FirebaseConfig.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/FirebaseConfig.kt
@@ -1,0 +1,30 @@
+package kr.dallyeobom.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import kr.dallyeobom.config.properties.FirebaseProperties
+import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
+
+@Configuration
+class FirebaseConfig(
+    private val firebaseProperties: FirebaseProperties,
+) {
+    @PostConstruct
+    fun init() {
+        if (FirebaseApp.getApps().isNotEmpty()) return
+
+        val credentials =
+            ByteArrayInputStream(firebaseProperties.firebaseServiceAccountJson.toByteArray())
+
+        val options =
+            FirebaseOptions
+                .builder()
+                .setCredentials(GoogleCredentials.fromStream(credentials))
+                .build()
+
+        FirebaseApp.initializeApp(options)
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/config/properties/FirebaseProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/FirebaseProperties.kt
@@ -2,7 +2,7 @@ package kr.dallyeobom.config.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties("firebase.fcm")
+@ConfigurationProperties("firebase")
 data class FirebaseProperties(
     val firebaseServiceAccountJson: String,
 )

--- a/src/main/kotlin/kr/dallyeobom/config/properties/FirebaseProperties.kt
+++ b/src/main/kotlin/kr/dallyeobom/config/properties/FirebaseProperties.kt
@@ -1,0 +1,8 @@
+package kr.dallyeobom.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("firebase.fcm")
+data class FirebaseProperties(
+    val firebaseServiceAccountJson: String,
+)

--- a/src/main/kotlin/kr/dallyeobom/controller/auth/request/KakaoLoginRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/auth/request/KakaoLoginRequest.kt
@@ -1,8 +1,13 @@
 package kr.dallyeobom.controller.auth.request
 
+import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
 data class KakaoLoginRequest(
+    @field:Schema(description = "카카오 로그인시 발급받은 엑세스 토큰")
     @field:NotBlank(message = "provider 엑세스 토큰은 필수입니다.")
     val providerAccessToken: String,
+    // FCM 토큰은 여러가지 이유로 만료될 수 있으나 로그인할때 받아두면 충분히 최신 토큰을 DB에 저장해둘 수 있다.
+    @field:Schema(description = "Firebase FCM 토큰 (선택사항)", example = "fcm_token_example")
+    val fcmToken: String?,
 )

--- a/src/main/kotlin/kr/dallyeobom/entity/User.kt
+++ b/src/main/kotlin/kr/dallyeobom/entity/User.kt
@@ -6,16 +6,20 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.DynamicUpdate
 
 @Entity
 @Table(
     name = "users", // Oracle에선 user라는 이름이 예약어라 users로 변경
 )
+@DynamicUpdate
 class User(
     @Column(length = 20, nullable = false, updatable = false, unique = true)
     val nickname: String,
     @Column(length = 30, nullable = false, updatable = false, unique = true)
     val email: String,
+    @Column(length = 200)
+    var fcmToken: String? = null,
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)

--- a/src/main/kotlin/kr/dallyeobom/service/UserService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/UserService.kt
@@ -79,13 +79,16 @@ class UserService(
         return ServiceTokensResponse(accessToken, refreshToken)
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     fun kakaoLogin(request: KakaoLoginRequest): KakaoLoginResponse {
         val kakaoProfile = kakaoApiClient.getKakaoProfile(request.providerAccessToken)
         val providerUserId = requireNotNull(kakaoProfile?.id) { "해당 계정 정보가 존재하지 않습니다." }
         val userOauthInfo = userOauthInfoRepository.findByProviderUserIdAndProvider(providerUserId, Provder.KAKAO)
 
         return userOauthInfo?.let {
+            if (request.fcmToken != it.user.fcmToken) {
+                it.user.fcmToken = request.fcmToken
+            }
             val tokens = makeTokens(it.user)
             KakaoLoginResponse(tokens.accessToken, tokens.refreshToken, isNewUser = false)
         } ?: KakaoLoginResponse(isNewUser = true)

--- a/src/main/kotlin/kr/dallyeobom/util/PushSendService.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/PushSendService.kt
@@ -2,7 +2,6 @@ package kr.dallyeobom.util
 
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.Message
-import com.google.firebase.messaging.MulticastMessage
 import kr.dallyeobom.entity.User
 import org.springframework.stereotype.Component
 
@@ -14,13 +13,13 @@ class PushSendService {
     fun sendPushToUser(
         user: User,
         data: Map<String, String>,
-    ) = user.fcmToken?.let { sendPushWithToken(it, data) }
+    ) = user.fcmToken?.let { sendPushWithToken(it, data) } ?: PushSendResult.failureWithoutError()
 
     // 한 유저의 토큰으로 푸시 알림을 보냅니다.
     fun sendPushWithToken(
         token: String,
         data: Map<String, String>,
-    ): String {
+    ): PushSendResult {
         val message =
             Message
                 .builder()
@@ -28,39 +27,21 @@ class PushSendService {
                 .putAllData(data)
                 .build()
 
-        return firebaseMessaging.send(message)
+        return sendPush(message)
     }
 
     fun sendPushToUsers(
         users: List<User>,
         data: Map<String, String>,
-    ): List<String?> {
-        val fcmToken =
-            users.mapNotNull { user ->
-                user.fcmToken
-            }
-        return sendPushWithMulticast(fcmToken, data)
-    }
-
-    // 여러 유저의 토큰으로 푸시 알림을 보냅니다.
-    fun sendPushWithMulticast(
-        tokens: List<String>,
-        data: Map<String, String>,
-    ): List<String?> {
-        val message =
-            MulticastMessage
-                .builder()
-                .addAllTokens(tokens)
-                .putAllData(data)
-                .build()
-        return firebaseMessaging.sendEachForMulticast(message).responses.map { it.messageId }
+    ) = users.associateWith { user ->
+        user.fcmToken?.let { sendPushWithToken(it, data) } ?: PushSendResult.failureWithoutError()
     }
 
     // 특정 토픽에 구독한 유저들에게 푸시 알림을 보냅니다.
     fun sendPushWithTopic(
         topic: String,
         data: Map<String, String>,
-    ): String {
+    ): PushSendResult {
         val message =
             Message
                 .builder()
@@ -68,6 +49,27 @@ class PushSendService {
                 .putAllData(data)
                 .build()
 
-        return firebaseMessaging.send(message)
+        return sendPush(message)
+    }
+
+    private fun sendPush(message: Message): PushSendResult =
+        try {
+            PushSendResult.success(firebaseMessaging.send(message))
+        } catch (e: Exception) {
+            PushSendResult.failure(e)
+        }
+
+    data class PushSendResult(
+        val success: Boolean,
+        val messageId: String? = null,
+        val error: Throwable? = null,
+    ) {
+        companion object {
+            fun success(messageId: String) = PushSendResult(true, messageId)
+
+            fun failure(error: Throwable) = PushSendResult(false, error = error)
+
+            fun failureWithoutError() = PushSendResult(false)
+        }
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/util/PushSendService.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/PushSendService.kt
@@ -1,0 +1,73 @@
+package kr.dallyeobom.util
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.MulticastMessage
+import kr.dallyeobom.entity.User
+import org.springframework.stereotype.Component
+
+@Component
+class PushSendService {
+    private val firebaseMessaging: FirebaseMessaging by lazy { FirebaseMessaging.getInstance() }
+
+    // 유저의 FCM 토큰으로 푸시 알림을 보냅니다.
+    fun sendPushToUser(
+        user: User,
+        data: Map<String, String>,
+    ) = user.fcmToken?.let { sendPushWithToken(it, data) }
+
+    // 한 유저의 토큰으로 푸시 알림을 보냅니다.
+    fun sendPushWithToken(
+        token: String,
+        data: Map<String, String>,
+    ): String {
+        val message =
+            Message
+                .builder()
+                .setToken(token)
+                .putAllData(data)
+                .build()
+
+        return firebaseMessaging.send(message)
+    }
+
+    fun sendPushToUsers(
+        users: List<User>,
+        data: Map<String, String>,
+    ): List<String?> {
+        val fcmToken =
+            users.mapNotNull { user ->
+                user.fcmToken
+            }
+        return sendPushWithMulticast(fcmToken, data)
+    }
+
+    // 여러 유저의 토큰으로 푸시 알림을 보냅니다.
+    fun sendPushWithMulticast(
+        tokens: List<String>,
+        data: Map<String, String>,
+    ): List<String?> {
+        val message =
+            MulticastMessage
+                .builder()
+                .addAllTokens(tokens)
+                .putAllData(data)
+                .build()
+        return firebaseMessaging.sendEachForMulticast(message).responses.map { it.messageId }
+    }
+
+    // 특정 토픽에 구독한 유저들에게 푸시 알림을 보냅니다.
+    fun sendPushWithTopic(
+        topic: String,
+        data: Map<String, String>,
+    ): String {
+        val message =
+            Message
+                .builder()
+                .setTopic(topic)
+                .putAllData(data)
+                .build()
+
+        return firebaseMessaging.send(message)
+    }
+}


### PR DESCRIPTION
### 개요
- 앱에 푸시를 보내기위한 기초 기능을 추가한다

### 변경사항
- FCM 연동
- FCM을 받아서 DB에 저장하는 플로우 추가
- 유저에게 푸시를 보내는 컴포넌트 구현

### 리뷰어에게 하고 싶은 말
- FCM 토큰이 여러 이유로 만료될수 있어서 토큰을 갱신할수 있는 플로우가 필요한데 저는 항상 유저 로그인시 받도록 작업하거든요
- 그래서 이번에도 로그인과 함께 FCM 토큰을 받도록 작업했는데 환우님 의견을 들어보고 싶네요!
