### PR TITLE
DAL-61 화면 기획과 차이나는 API 수정

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
@@ -7,6 +7,7 @@ import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.CourseLikeResponse
 import kr.dallyeobom.controller.course.response.CourseRankResponse
+import kr.dallyeobom.controller.course.response.CourseReviewResponse
 import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
 import kr.dallyeobom.controller.course.response.NearByUserRunningCourseResponse
 import kr.dallyeobom.service.CourseService
@@ -107,4 +108,11 @@ class CourseController(
     override fun deleteRunningCourse(
         @LoginUserId userId: Long,
     ) = courseService.deleteRunningCourse(userId)
+
+    @GetMapping("/{id}/review")
+    override fun getCourseReviews(
+        @PathVariable
+        id: Long,
+        sliceRequest: SliceRequest,
+    ): SliceResponse<CourseReviewResponse> = courseService.getCourseReviews(id, sliceRequest)
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
@@ -14,6 +14,7 @@ import kr.dallyeobom.controller.course.request.NearByCourseSearchRequest
 import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.CourseLikeResponse
 import kr.dallyeobom.controller.course.response.CourseRankResponse
+import kr.dallyeobom.controller.course.response.CourseReviewResponse
 import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
 import kr.dallyeobom.controller.course.response.NearByUserRunningCourseResponse
 import kr.dallyeobom.util.validator.MaxFileSize
@@ -163,6 +164,7 @@ interface CourseControllerSpec {
                 description = """
         잘못된 요청:
         • 코스 ID가 양수가 아님  
+        • 마지막 조회 ID가 양수가 아님
         • 조회 사이즈가 양수가 아님
       """,
                 content = arrayOf(Content()),
@@ -228,4 +230,30 @@ interface CourseControllerSpec {
         ],
     )
     fun deleteRunningCourse(userId: Long)
+
+    @Operation(
+        summary = "코스 리뷰 조회",
+        description = "코스 ID를 입력받아 해당 코스의 리뷰를 조회합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "코스 리뷰 조회 성공"),
+            ApiResponse(
+                responseCode = "400",
+                description = """
+        잘못된 요청:
+        • 코스 ID가 양수가 아님  
+        • 마지막 조회 ID가 양수가 아님
+        • 조회 사이즈가 양수가 아님
+      """,
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 코스가 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun getCourseReviews(
+        @Positive(message = "코스 ID는 양수여야 합니다.")
+        @Schema(description = "리뷰를 조회하고자 하는 코스의 ID", example = "1")
+        id: Long,
+        @Validated
+        @ParameterObject sliceRequest: SliceRequest,
+    ): SliceResponse<CourseReviewResponse>
 }

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
@@ -164,7 +164,6 @@ interface CourseControllerSpec {
                 description = """
         잘못된 요청:
         • 코스 ID가 양수가 아님  
-        • 마지막 조회 ID가 양수가 아님
         • 조회 사이즈가 양수가 아님
       """,
                 content = arrayOf(Content()),

--- a/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseReviewResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseReviewResponse.kt
@@ -1,0 +1,38 @@
+package kr.dallyeobom.controller.course.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.dallyeobom.controller.common.response.SimpleUserResponse
+import kr.dallyeobom.entity.CourseCompletionHistory
+import java.time.format.DateTimeFormatter
+
+data class CourseReviewResponse(
+    @Schema(description = "코스 리뷰 ID", example = "1")
+    val id: Long,
+    @Schema(description = "리뷰 작성자 정보")
+    val user: SimpleUserResponse,
+    @Schema(description = "코스 리뷰 내용", example = "정말 좋은 코스였습니다!")
+    val review: String,
+    @Schema(
+        description = "코스 완료 이미지 URL 목록",
+        example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]",
+    )
+    val completionImages: List<String>?,
+    @Schema(description = "리뷰 작성 날짜", example = "2025.07.01")
+    val createdAt: String,
+) {
+    companion object {
+        private val dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+        fun from(
+            courseCompletionHistory: CourseCompletionHistory,
+            profileImage: String?,
+            completionImages: List<String>?,
+        ) = CourseReviewResponse(
+            id = courseCompletionHistory.id,
+            user = SimpleUserResponse.from(courseCompletionHistory.user, profileImage),
+            review = courseCompletionHistory.review,
+            completionImages = completionImages,
+            createdAt = dateTimeFormatter.format(courseCompletionHistory.createdDateTime),
+        )
+    }
+}

--- a/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseReviewResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseReviewResponse.kt
@@ -13,7 +13,7 @@ data class CourseReviewResponse(
     @Schema(description = "코스 리뷰 내용", example = "정말 좋은 코스였습니다!")
     val review: String,
     @Schema(
-        description = "코스 완료 이미지 URL 목록",
+        description = "코스 완료 이미지 URL 목록 - 없으면 null",
         example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]",
     )
     val completionImages: List<String>?,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -38,8 +38,8 @@ class CourseCompletionHistoryController(
         request: CourseCompletionCreateRequest,
         @RequestPart(required = false)
         courseImage: MultipartFile?,
-        @RequestPart
-        completionImages: List<MultipartFile>,
+        @RequestPart(required = false)
+        completionImages: List<MultipartFile>?,
     ): CourseCompletionCreateResponse =
         courseCompletionHistoryService.createCourseCompletionHistory(userId, request, courseImage, completionImages)
 

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -65,13 +65,15 @@ class CourseCompletionHistoryController(
         courseImage: MultipartFile?,
     ) = courseCompletionHistoryService.createCourseFromCompletionHistory(userId, id, request, courseImage)
 
-    @GetMapping("/user/{userId}")
+    @GetMapping("/user/{id}")
     override fun getCourseCompletionHistoryListByUserId(
+        @LoginUserId
+        loginUserId: Long,
         @PathVariable
-        userId: Long,
+        id: Long,
         sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse> =
-        courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(userId, sliceRequest)
+        courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(loginUserId, id, sliceRequest)
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -16,6 +16,7 @@ import kr.dallyeobom.controller.courseCompletionHistory.request.CourseCreateRequ
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionCreateResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryDetailResponse
 import kr.dallyeobom.controller.courseCompletionHistory.response.CourseCompletionHistoryResponse
+import kr.dallyeobom.util.MAX_COMPLETION_IMAGE_COUNT
 import kr.dallyeobom.util.validator.MaxFileSize
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.validation.annotation.Validated
@@ -42,7 +43,7 @@ interface CourseCompletionHistoryControllerSpec {
         • 공개 설정이 PUBLIC인데 생성 정보가 없는경우
         • 코스 설명이 1자 미만이거나 500자를 초과함
         • 코스명이 1자 미만이거나 30자를 초과함
-        • 코스 인증샷이 3개를 초과함
+        • 코스 인증샷이 ${MAX_COMPLETION_IMAGE_COUNT}개를 초과함
         • 파일 사이즈가 1MB를 초과함
       """,
                 content = arrayOf(Content()),
@@ -57,8 +58,8 @@ interface CourseCompletionHistoryControllerSpec {
         @Schema(description = "코스 대표사진 - 코스 등록시에만 사용하며 없어도됨, 사진의 최대 크기는 1MB")
         courseImage: MultipartFile?,
         @MaxFileSize
-        @Size(max = 3, message = "인증샷은 최대 3개까지 업로드할 수 있습니다.")
-        @Schema(description = "코스 완주 인증샷들 - 3개까지 업로드 가능, 각 사진의 최대 크기는 1MB")
+        @Size(max = MAX_COMPLETION_IMAGE_COUNT, message = "인증샷은 최대 ${MAX_COMPLETION_IMAGE_COUNT}개까지 업로드할 수 있습니다.")
+        @Schema(description = "코스 완주 인증샷들 - ${MAX_COMPLETION_IMAGE_COUNT}개까지 업로드 가능, 각 사진의 최대 크기는 1MB")
         completionImages: List<MultipartFile>?,
     ): CourseCompletionCreateResponse
 
@@ -173,7 +174,7 @@ interface CourseCompletionHistoryControllerSpec {
         잘못된 요청:
         • 코스 완주 기록 ID가 양수가 아님  
         • 리뷰의 길이가 1자 미만이거나 300자를 초과함
-        • 코스 인증샷이 3개를 초과함
+        • 코스 인증샷이 ${MAX_COMPLETION_IMAGE_COUNT}개를 초과함
         • 파일 사이즈가 1MB를 초과함
       """,
                 content = arrayOf(Content()),
@@ -197,7 +198,7 @@ interface CourseCompletionHistoryControllerSpec {
         id: Long,
         @Validated request: CourseCompletionUpdateRequest,
         @MaxFileSize
-        @Size(max = 3, message = "인증샷은 최대 3개까지 업로드할 수 있습니다.")
+        @Size(max = MAX_COMPLETION_IMAGE_COUNT, message = "인증샷은 최대 ${MAX_COMPLETION_IMAGE_COUNT}개까지 업로드할 수 있습니다.")
         @Schema(description = "추가할 코스 완주 인증샷들 - null도 가능하며 기존에 올린 인증샷 포함 최대 3개까지 업로드 가능, 각 사진의 최대 크기는 1MB")
         completionImages: List<MultipartFile>?,
     )

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -129,9 +129,10 @@ interface CourseCompletionHistoryControllerSpec {
         ],
     )
     fun getCourseCompletionHistoryListByUserId(
+        loginUserId: Long,
         @Positive(message = "유저 ID는 양수여야 합니다.")
         @Schema(description = "조회하고자 하는 유저의 ID", example = "1")
-        userId: Long,
+        id: Long,
         @Validated
         @ParameterObject sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse>

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -42,7 +42,7 @@ interface CourseCompletionHistoryControllerSpec {
         • 공개 설정이 PUBLIC인데 생성 정보가 없는경우
         • 코스 설명이 1자 미만이거나 500자를 초과함
         • 코스명이 1자 미만이거나 30자를 초과함
-        • 코스 인증샷이 1개 미만이거나 3개를 초과함
+        • 코스 인증샷이 3개를 초과함
         • 파일 사이즈가 1MB를 초과함
       """,
                 content = arrayOf(Content()),
@@ -57,9 +57,9 @@ interface CourseCompletionHistoryControllerSpec {
         @Schema(description = "코스 대표사진 - 코스 등록시에만 사용하며 없어도됨, 사진의 최대 크기는 1MB")
         courseImage: MultipartFile?,
         @MaxFileSize
-        @Size(min = 1, max = 3, message = "인증샷은 최소 1개에서 최대 3개까지 업로드할 수 있습니다.")
-        @Schema(description = "코스 완주 인증샷들 - 1 ~ 3개까지 업로드 가능, 각 사진의 최대 크기는 1MB")
-        completionImages: List<MultipartFile>,
+        @Size(max = 3, message = "인증샷은 최대 3개까지 업로드할 수 있습니다.")
+        @Schema(description = "코스 완주 인증샷들 - 3개까지 업로드 가능, 각 사진의 최대 크기는 1MB")
+        completionImages: List<MultipartFile>?,
     ): CourseCompletionCreateResponse
 
     @Operation(
@@ -172,7 +172,7 @@ interface CourseCompletionHistoryControllerSpec {
         잘못된 요청:
         • 코스 완주 기록 ID가 양수가 아님  
         • 리뷰의 길이가 1자 미만이거나 300자를 초과함
-        • 코스 인증샷이 1개 미만이거나 3개를 초과함
+        • 코스 인증샷이 3개를 초과함
         • 파일 사이즈가 1MB를 초과함
       """,
                 content = arrayOf(Content()),

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionUpdateRequest.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/request/CourseCompletionUpdateRequest.kt
@@ -2,6 +2,7 @@ package kr.dallyeobom.controller.courseCompletionHistory.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
+import kr.dallyeobom.util.MAX_COMPLETION_IMAGE_COUNT
 import org.hibernate.validator.constraints.Length
 
 data class CourseCompletionUpdateRequest(
@@ -9,6 +10,6 @@ data class CourseCompletionUpdateRequest(
     @field:Length(min = 1, max = 300, message = "리뷰는 최소 1자, 최대 300자까지 입력 가능합니다. null이면 기존 리뷰를 유지합니다.")
     val review: String?,
     @field:Schema(description = "지우고자 하는 코스 인증샷 ID 리스트 - null이면 기존 인증샷을 유지합니다.", example = "[1, 3]")
-    @field:Size(max = 3, message = "인증샷은 최대 3개까지 삭제할 수 있습니다.")
+    @field:Size(max = MAX_COMPLETION_IMAGE_COUNT, message = "인증샷은 최대 ${MAX_COMPLETION_IMAGE_COUNT}개까지 삭제할 수 있습니다.")
     val deleteImageIds: Set<Long>?,
 )

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
@@ -12,7 +12,7 @@ data class CourseCompletionHistoryResponse(
     val interval: Long,
     @Schema(description = "거리 (미터)", example = "5000")
     val length: Int,
-    @Schema(description = "코스 완주 인증샷", example = "\"https://example.com/image.jpg\"")
+    @Schema(description = "코스 완주 인증샷", example = "https://example.com/image.jpg")
     val completionImage: String?,
     @Schema(description = "좋아요 여부", example = "true")
     val isLiked: Boolean,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
@@ -13,12 +13,15 @@ data class CourseCompletionHistoryResponse(
     @Schema(description = "거리 (미터)", example = "5000")
     val length: Int,
     @Schema(description = "코스 완주 인증샷", example = "\"https://example.com/image.jpg\"")
-    val completionImage: String,
+    val completionImage: String?,
+    @Schema(description = "좋아요 여부", example = "true")
+    val isLiked: Boolean,
 ) {
     companion object {
         fun from(
             item: CourseCompletionHistory,
-            imageUrl: String,
+            imageUrl: String?,
+            isLiked: Boolean,
         ): CourseCompletionHistoryResponse =
             CourseCompletionHistoryResponse(
                 id = item.id,
@@ -26,6 +29,7 @@ data class CourseCompletionHistoryResponse(
                 interval = item.interval.toSeconds(),
                 length = item.length,
                 completionImage = imageUrl,
+                isLiked = isLiked,
             )
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
@@ -1,5 +1,6 @@
 package kr.dallyeobom.exception
 
+import kr.dallyeobom.util.MAX_COMPLETION_IMAGE_COUNT
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(
@@ -13,7 +14,7 @@ enum class ErrorCode(
     ALREADY_CREATED_COURSE(HttpStatus.BAD_REQUEST, 40002, "이미 생성된 코스입니다."),
     INVALID_REQUIRED_TERMS_POLICY(HttpStatus.BAD_REQUEST, 40003, "필수 이용약관은 동의해야합니다."),
     INVALID_RECENT_TERMS_POLICY(HttpStatus.BAD_REQUEST, 40004, "현재 이용약관이어야 합니다."),
-    INVALID_COURSE_COMPLETION_IMAGE_COUNT(HttpStatus.BAD_REQUEST, 40005, "인증샷은 최대 3개까지 업로드할 수 있습니다."),
+    INVALID_COURSE_COMPLETION_IMAGE_COUNT(HttpStatus.BAD_REQUEST, 40005, "인증샷은 최대 ${MAX_COMPLETION_IMAGE_COUNT}개까지 업로드할 수 있습니다."),
 
     // UNAUTHORIZED는 40100부터 시작
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),

--- a/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/dallyeobom/exception/ErrorCode.kt
@@ -13,7 +13,7 @@ enum class ErrorCode(
     ALREADY_CREATED_COURSE(HttpStatus.BAD_REQUEST, 40002, "이미 생성된 코스입니다."),
     INVALID_REQUIRED_TERMS_POLICY(HttpStatus.BAD_REQUEST, 40003, "필수 이용약관은 동의해야합니다."),
     INVALID_RECENT_TERMS_POLICY(HttpStatus.BAD_REQUEST, 40004, "현재 이용약관이어야 합니다."),
-    INVALID_COURSE_COMPLETION_IMAGE_COUNT(HttpStatus.BAD_REQUEST, 40005, "인증샷은 최소 1개에서 최대 3개까지 업로드할 수 있습니다."),
+    INVALID_COURSE_COMPLETION_IMAGE_COUNT(HttpStatus.BAD_REQUEST, 40005, "인증샷은 최대 3개까지 업로드할 수 있습니다."),
 
     // UNAUTHORIZED는 40100부터 시작
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -30,6 +30,7 @@ import kr.dallyeobom.repository.ObjectStorageRepository
 import kr.dallyeobom.repository.UserRepository
 import kr.dallyeobom.util.CourseCreateUtil
 import kr.dallyeobom.util.CourseLengthUtil
+import kr.dallyeobom.util.MAX_COMPLETION_IMAGE_COUNT
 import kr.dallyeobom.util.lock.RedisLock
 import kr.dallyeobom.util.requireNull
 import org.springframework.stereotype.Service
@@ -263,7 +264,7 @@ class CourseCompletionHistoryService(
 
         val existingImages = courseCompletionImageRepository.findAllByCompletion(courseCompletionHistory)
         val imageCount = existingImages.size + (completionImages?.size ?: 0) - (request.deleteImageIds?.size ?: 0)
-        if (imageCount > 3) {
+        if (imageCount > MAX_COMPLETION_IMAGE_COUNT) {
             throw InvalidCourseCompletionImageCountException()
         }
         request.review?.let { courseCompletionHistory.review = it }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -51,7 +51,7 @@ class CourseCompletionHistoryService(
         userId: Long,
         request: CourseCompletionCreateRequest,
         courseImage: MultipartFile?,
-        completionImages: List<MultipartFile>,
+        completionImages: List<MultipartFile>?,
     ): CourseCompletionCreateResponse {
         val user = userRepository.findById(userId).orElseThrow { UserNotFoundException(userId) }
         val courseCompletionHistory =
@@ -67,10 +67,12 @@ class CourseCompletionHistoryService(
                     ),
                 )
 
-        saveCompletionImages(
-            courseCompletionHistory,
-            completionImages,
-        )
+        completionImages?.let {
+            saveCompletionImages(
+                courseCompletionHistory,
+                it,
+            )
+        }
 
         return CourseCompletionCreateResponse.from(courseCompletionHistory)
     }
@@ -248,7 +250,7 @@ class CourseCompletionHistoryService(
 
         val existingImages = courseCompletionImageRepository.findAllByCompletion(courseCompletionHistory)
         val imageCount = existingImages.size + (completionImages?.size ?: 0) - (request.deleteImageIds?.size ?: 0)
-        if (imageCount !in 1..3) {
+        if (imageCount > 3) {
             throw InvalidCourseCompletionImageCountException()
         }
         request.review?.let { courseCompletionHistory.review = it }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -295,7 +295,7 @@ class CourseService(
                 CourseReviewResponse.from(
                     completionHistory,
                     completionHistory.user.profileImage?.let { image -> objectStorageRepository.getDownloadUrl(image) },
-                    imageMap[completionHistory]?.map { objectStorageRepository.getDownloadUrl(it.image) } ?: emptyList(),
+                    imageMap[completionHistory]?.map { objectStorageRepository.getDownloadUrl(it.image) },
                 )
             }
         return SliceResponse.from(reviewResponses, completionHistories.lastOrNull()?.id)

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -319,13 +319,13 @@ class CourseService(
     ): SliceResponse<CourseReviewResponse> {
         val course = courseRepository.findById(id).getOrNull() ?: throw CourseNotFoundException()
         val completionHistories = courseCompletionHistoryRepository.findSliceByCourse(course, sliceRequest)
-        val imageMap = courseCompletionImageRepository.findAllByCompletionIn(completionHistories.content).groupBy { it.completion }
+        val imageMap = courseCompletionImageRepository.findAllByCompletionIn(completionHistories.content).groupBy { it.completion.id }
         val reviewResponses =
             completionHistories.map { completionHistory ->
                 CourseReviewResponse.from(
                     completionHistory,
                     completionHistory.user.profileImage?.let { image -> objectStorageRepository.getDownloadUrl(image) },
-                    imageMap[completionHistory]?.map { objectStorageRepository.getDownloadUrl(it.image) },
+                    imageMap[completionHistory.id]?.map { objectStorageRepository.getDownloadUrl(it.image) },
                 )
             }
         return SliceResponse.from(reviewResponses, completionHistories.lastOrNull()?.id)

--- a/src/main/kotlin/kr/dallyeobom/util/Constants.kt
+++ b/src/main/kotlin/kr/dallyeobom/util/Constants.kt
@@ -1,0 +1,3 @@
+package kr.dallyeobom.util
+
+const val MAX_COMPLETION_IMAGE_COUNT = 5


### PR DESCRIPTION
### 개요
- 코스 리뷰를 조회할수 있는 API가 필요하다
- 코스 완주 인증샷을 없을수도 있다
- 유저가 뛴 코스에선 좋아요 여부가 필요하다

### 변경사항
- 코스 리뷰 Slice조회 API 추가
- 코스 완주 인증 등록시 이미지 없어도 되도록 수정
- 코스 완주 인증샷이 1개이상 있을것이라 예상하고 작업된 코드 수정
- 유저 뛴 코드 API 응답에 현재 유저의 코스별 좋아요 여부 추가


### 리뷰어에게 하고 싶은 말
- 디자인이 나올때마다 제가 예상한것과 다른게 한두개씩 나오는군요 ㅋㅋㅋ