### PR TITLE
DAL-68 유저 기록 API 수정 및 완주 코스 조회 API 추가

### DIFF
--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseController.kt
@@ -8,7 +8,7 @@ import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.CourseLikeResponse
 import kr.dallyeobom.controller.course.response.CourseRankResponse
 import kr.dallyeobom.controller.course.response.CourseReviewResponse
-import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
+import kr.dallyeobom.controller.course.response.CourseSearchResponse
 import kr.dallyeobom.controller.course.response.NearByUserRunningCourseResponse
 import kr.dallyeobom.controller.course.response.UserLikedCourseResponse
 import kr.dallyeobom.service.CourseService
@@ -45,7 +45,7 @@ class CourseController(
         @LoginUserId
         userId: Long,
         request: NearByCourseSearchRequest,
-    ): List<NearByCourseSearchResponse> = courseService.searchNearByLocation(userId, request)
+    ): List<CourseSearchResponse> = courseService.searchNearByLocation(userId, request)
 
     @GetMapping("/{id}")
     override fun getCourseDetail(
@@ -118,6 +118,15 @@ class CourseController(
         id: Long,
         sliceRequest: SliceRequest,
     ): SliceResponse<UserLikedCourseResponse> = courseService.getUserLikeCourses(userId, id, sliceRequest)
+
+    @GetMapping("user/{id}/completed")
+    override fun getUserCompletedCourses(
+        @LoginUserId
+        userId: Long,
+        @PathVariable
+        id: Long,
+        sliceRequest: SliceRequest,
+    ): SliceResponse<CourseSearchResponse> = courseService.getUserCompletedCourses(userId, id, sliceRequest)
 
     @GetMapping("/{id}/review")
     override fun getCourseReviews(

--- a/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/CourseControllerSpec.kt
@@ -15,7 +15,7 @@ import kr.dallyeobom.controller.course.response.CourseDetailResponse
 import kr.dallyeobom.controller.course.response.CourseLikeResponse
 import kr.dallyeobom.controller.course.response.CourseRankResponse
 import kr.dallyeobom.controller.course.response.CourseReviewResponse
-import kr.dallyeobom.controller.course.response.NearByCourseSearchResponse
+import kr.dallyeobom.controller.course.response.CourseSearchResponse
 import kr.dallyeobom.controller.course.response.NearByUserRunningCourseResponse
 import kr.dallyeobom.controller.course.response.UserLikedCourseResponse
 import kr.dallyeobom.util.validator.MaxFileSize
@@ -55,7 +55,7 @@ interface CourseControllerSpec {
         userId: Long,
         @Validated
         @ParameterObject request: NearByCourseSearchRequest,
-    ): List<NearByCourseSearchResponse>
+    ): List<CourseSearchResponse>
 
     @Operation(
         summary = "코스 상세 조회",
@@ -256,6 +256,33 @@ interface CourseControllerSpec {
         @Validated
         @ParameterObject sliceRequest: SliceRequest,
     ): SliceResponse<UserLikedCourseResponse>
+
+    @Operation(
+        summary = "특정 유저가 완주한 코스 조회",
+        description = "특정 유저가 완주한 코스 리스트를 조회합니다. 서버 조회 성능을 위해 무한스크롤 방식으로 구현되었습니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "코스 정보 리스트"),
+            ApiResponse(
+                responseCode = "400",
+                description = """
+        잘못된 요청:
+        • 조회하고자 하는 유저 ID가 양수가 아님
+        • 마지막 조회 ID가 양수가 아님
+        • 조회하고자 하는 리스트 크기가 양수가 아님
+      """,
+                content = arrayOf(Content()),
+            ),
+            ApiResponse(responseCode = "404", description = "ID에 해당하는 유저가 존재하지 않음", content = arrayOf(Content())),
+        ],
+    )
+    fun getUserCompletedCourses(
+        userId: Long,
+        @Positive(message = "유저 ID는 양수여야 합니다.")
+        @Schema(description = "조회하고자 하는 유저의 ID", example = "1")
+        id: Long,
+        @Validated
+        @ParameterObject sliceRequest: SliceRequest,
+    ): SliceResponse<CourseSearchResponse>
 
     @Operation(
         summary = "코스 리뷰 조회",

--- a/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseSearchResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/course/response/CourseSearchResponse.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import kr.dallyeobom.entity.Course
 import kr.dallyeobom.entity.CourseLevel
 
-data class NearByCourseSearchResponse(
+data class CourseSearchResponse(
     @Schema(description = "코스 ID", example = "1")
     val id: Long,
     @Schema(description = "코스명", example = "장충동 산5 15 Climb")
@@ -25,7 +25,7 @@ data class NearByCourseSearchResponse(
             course: Course,
             overViewImageUrl: String,
             isLiked: Boolean,
-        ) = NearByCourseSearchResponse(
+        ) = CourseSearchResponse(
             id = course.id,
             name = course.name,
             location = course.location,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryController.kt
@@ -67,13 +67,11 @@ class CourseCompletionHistoryController(
 
     @GetMapping("/user/{id}")
     override fun getCourseCompletionHistoryListByUserId(
-        @LoginUserId
-        loginUserId: Long,
         @PathVariable
         id: Long,
         sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse> =
-        courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(loginUserId, id, sliceRequest)
+        courseCompletionHistoryService.getCourseCompletionHistoryListByUserId(id, sliceRequest)
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/CourseCompletionHistoryControllerSpec.kt
@@ -130,7 +130,6 @@ interface CourseCompletionHistoryControllerSpec {
         ],
     )
     fun getCourseCompletionHistoryListByUserId(
-        loginUserId: Long,
         @Positive(message = "유저 ID는 양수여야 합니다.")
         @Schema(description = "조회하고자 하는 유저의 ID", example = "1")
         id: Long,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryDetailResponse.kt
@@ -3,14 +3,15 @@ package kr.dallyeobom.controller.courseCompletionHistory.response
 import io.swagger.v3.oas.annotations.media.Schema
 import kr.dallyeobom.dto.LatLngDto
 import kr.dallyeobom.entity.CourseCompletionHistory
+import java.time.format.DateTimeFormatter
 
 class CourseCompletionHistoryDetailResponse(
     @Schema(description = "코스 완료 이력 ID", example = "1")
     val id: Long = 0L,
     @Schema(description = "코스 ID", example = "1")
     val courseId: Long?,
-    @Schema(description = "코스명", example = "장충동 산5 15 Climb")
-    val courseName: String?,
+    @Schema(description = "코스명 혹은 기록명", example = "장충동 산5 15 Climb | 8월 2일 기록")
+    val title: String,
     @Schema(description = "현재 유저가 해당 코스의 생성자 인지 여부, 코스 ID가 없으면 null - 이 값을 가지고 나중에 코스 수정 API 호출 가능 여부를 결정하면 됩니다", example = "true")
     val isCreator: Boolean?,
     @Schema(description = "유저 ID", example = "1")
@@ -30,6 +31,8 @@ class CourseCompletionHistoryDetailResponse(
     val completionImages: List<CourseCompletionImageResponse>,
 ) {
     companion object {
+        private val dateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일 기록")
+
         fun from(
             userId: Long,
             courseCompletionHistory: CourseCompletionHistory,
@@ -38,7 +41,7 @@ class CourseCompletionHistoryDetailResponse(
             CourseCompletionHistoryDetailResponse(
                 id = courseCompletionHistory.id,
                 courseId = courseCompletionHistory.course?.id,
-                courseName = courseCompletionHistory.course?.name,
+                title = courseCompletionHistory.course?.name ?: dateTimeFormatter.format(courseCompletionHistory.createdDateTime),
                 isCreator = courseCompletionHistory.course?.let { it.creatorId == userId },
                 userId = courseCompletionHistory.user.id,
                 review = courseCompletionHistory.review,

--- a/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
+++ b/src/main/kotlin/kr/dallyeobom/controller/courseCompletionHistory/response/CourseCompletionHistoryResponse.kt
@@ -2,37 +2,34 @@ package kr.dallyeobom.controller.courseCompletionHistory.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import kr.dallyeobom.entity.CourseCompletionHistory
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 data class CourseCompletionHistoryResponse(
     @Schema(description = "코스 완주 기록 ID", example = "1")
     val id: Long,
     @Schema(description = "연결된 코스 ID", example = "1")
     val courseId: Long?,
-    @Schema(description = "코스명", example = "장충동 산5 15 Climb")
-    val courseName: String?,
+    @Schema(description = "코스명 혹은 기록명", example = "장충동 산5 15 Climb | 8월 2일 기록")
+    val title: String,
     @Schema(description = "걸린시간 (초)", example = "3600")
     val interval: Long,
     @Schema(description = "거리 (미터)", example = "5000")
     val length: Int,
-    @Schema(description = "코스 완주 인증샷", example = "https://example.com/image.jpg")
-    val completionImage: String?,
-    @Schema(description = "좋아요 여부", example = "true")
-    val isLiked: Boolean,
+    @Schema(description = "완주 일자", example = "2025-08-02")
+    val completeDate: LocalDate,
 ) {
     companion object {
-        fun from(
-            item: CourseCompletionHistory,
-            imageUrl: String?,
-            isLiked: Boolean,
-        ): CourseCompletionHistoryResponse =
+        private val dateTimeFormatter = DateTimeFormatter.ofPattern("M월 d일 기록")
+
+        fun from(item: CourseCompletionHistory): CourseCompletionHistoryResponse =
             CourseCompletionHistoryResponse(
                 id = item.id,
                 courseId = item.course?.id,
-                courseName = item.course?.name,
+                title = item.course?.name ?: dateTimeFormatter.format(item.createdDateTime),
                 interval = item.interval.toSeconds(),
                 length = item.length,
-                completionImage = imageUrl,
-                isLiked = isLiked,
+                completeDate = item.createdDateTime.toLocalDate(),
             )
     }
 }

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CourseRepository :
     JpaRepository<Course, Long>,
-    CustomCourseRepository
+    CustomCourseRepository {
+    fun findAllByIdInOrderByIdDesc(ids: List<Long>): List<Course>
+}
 
 interface CustomCourseRepository {
     fun findNearByCourseByLocation(

--- a/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
+++ b/src/main/kotlin/kr/dallyeobom/repository/CourseRepository.kt
@@ -1,9 +1,14 @@
 package kr.dallyeobom.repository
 
 import com.linecorp.kotlinjdsl.support.spring.data.jpa.repository.KotlinJdslJpqlExecutor
+import kr.dallyeobom.controller.common.request.SliceRequest
 import kr.dallyeobom.entity.Course
 import kr.dallyeobom.entity.CourseCompletionHistory
+import kr.dallyeobom.entity.User
 import kr.dallyeobom.util.getAll
+import kr.dallyeobom.util.getSlice
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
@@ -19,6 +24,11 @@ interface CustomCourseRepository {
         radius: Int,
         maxCount: Int,
     ): List<Course>
+
+    fun findUserCompletedCourseIds(
+        user: User,
+        sliceRequest: SliceRequest,
+    ): Slice<Long>
 }
 
 class CustomCourseRepositoryImpl(
@@ -53,5 +63,21 @@ class CustomCourseRepositoryImpl(
                         .asSubquery()
                         .desc(),
                 )
+        }
+
+    override fun findUserCompletedCourseIds(
+        user: User,
+        sliceRequest: SliceRequest,
+    ): Slice<Long> =
+        kotlinJdslJpqlExecutor.getSlice(Pageable.ofSize(sliceRequest.size)) {
+            selectDistinct(path(Course::id))
+                .from(
+                    entity(CourseCompletionHistory::class),
+                    join(CourseCompletionHistory::course),
+                ).whereAnd(
+                    path(CourseCompletionHistory::user).eq(user),
+                    path(Course::deletedDateTime).isNull(),
+                    sliceRequest.lastId?.let { path(Course::id).lt(it) },
+                ).orderBy(path(Course::id).desc())
         }
 }

--- a/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseCompletionHistoryService.kt
@@ -24,7 +24,6 @@ import kr.dallyeobom.exception.NotCourseCompletionHistoryCreatorException
 import kr.dallyeobom.exception.UserNotFoundException
 import kr.dallyeobom.repository.CourseCompletionHistoryRepository
 import kr.dallyeobom.repository.CourseCompletionImageRepository
-import kr.dallyeobom.repository.CourseLikeHistoryRepository
 import kr.dallyeobom.repository.CourseRepository
 import kr.dallyeobom.repository.ObjectStorageRepository
 import kr.dallyeobom.repository.UserRepository
@@ -47,7 +46,6 @@ class CourseCompletionHistoryService(
     private val objectStorageRepository: ObjectStorageRepository,
     private val userRepository: UserRepository,
     private val courseCompletionImageRepository: CourseCompletionImageRepository,
-    private val courseLikeHistoryRepository: CourseLikeHistoryRepository,
 ) {
     @Transactional
     fun createCourseCompletionHistory(
@@ -132,36 +130,16 @@ class CourseCompletionHistoryService(
 
     @Transactional(readOnly = true)
     fun getCourseCompletionHistoryListByUserId(
-        loginUserId: Long,
         id: Long,
         sliceRequest: SliceRequest,
     ): SliceResponse<CourseCompletionHistoryResponse> {
         val user = userRepository.findById(id).orElseThrow { UserNotFoundException(id) }
         val courseCompletionHistories =
             courseCompletionHistoryRepository.findSliceByUser(user, sliceRequest)
-        val completionImageMap =
-            courseCompletionImageRepository
-                .findAllByCompletionIn(
-                    courseCompletionHistories.content,
-                ).associateBy { it.completion.id }
-
-        val likedCourseIds =
-            courseLikeHistoryRepository
-                .findByUserIdAndCourseIn(
-                    loginUserId,
-                    courseCompletionHistories.content.mapNotNull { it.course },
-                ).map { it.course.id }
-                .toSet()
         return SliceResponse.from(
             courseCompletionHistories.map { courseCompletionHistory ->
                 CourseCompletionHistoryResponse.from(
                     courseCompletionHistory,
-                    completionImageMap[courseCompletionHistory.id]?.image?.let {
-                        objectStorageRepository.getDownloadUrl(
-                            it,
-                        )
-                    },
-                    courseCompletionHistory.course?.id in likedCourseIds,
                 )
             },
             courseCompletionHistories.lastOrNull()?.id,

--- a/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
+++ b/src/main/kotlin/kr/dallyeobom/service/CourseService.kt
@@ -323,8 +323,7 @@ class CourseService(
         val user = userRepository.findById(id).orElseThrow { UserNotFoundException(id) }
         // completedCourseIds와 completedCourses를 쿼리 한번으로 가져오려면 비효율적인 쿼리로 나와서 2번 쿼리로 나눠서 처리한다
         val completedCourseIds = courseRepository.findUserCompletedCourseIds(user, sliceRequest)
-        val completedCourses =
-            courseRepository.findAllById(completedCourseIds.content).sortedByDescending { it.id }
+        val completedCourses = courseRepository.findAllByIdInOrderByIdDesc(completedCourseIds.content)
 
         val likedCourseIds =
             courseLikeHistoryRepository


### PR DESCRIPTION
### 개요
- 유저 기록 조회하는 API와 유저가 완주한 코스를 조회하는 API가 각각 필요한데 애매하게 두개가 합쳐진 API로 존재하고 있었다

### 변경사항
- 기존의 완주 이력 조회 하는 API는 기록만 조회하는 용도로 변경
- 완주 코스를 조회하는 API를 별도 추가


### 리뷰어에게 하고 싶은 말
- 요것도 제가 예상한 기획과 달라진 부분이라 재작업? 했습니다~! ㅋㅋㅋㅋ
