### PR TITLE
DAL-67 유저 랭킹 조회 버그 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 
     // Infrastructure
     implementation("com.oracle.database.jdbc:ojdbc11:23.8.0.25.04")
-    implementation("org.redisson:redisson-spring-boot-starter:3.47.0")
+    implementation("org.redisson:redisson-spring-boot-starter:3.51.0")
     implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.2.1") // 3.3버전에 이슈가 있어서 올리면 안됨
     // implementation("org.hibernate.search:hibernate-search-backend-elasticsearch:7.2.3.Final") // OpenSearch를 사용하게되면 주석 해제
 


### PR DESCRIPTION
### 개요
- 이전에 사용중이였던 Redisson라이브러리의 버그로 Netty 소켓관련 에러가 발생하고 있었다
- [참고](https://github.com/redisson/redisson/issues/6715)

### 변경사항
- 기존에 사용중이던 Redisson 3.47 버전에서 3.51버전으로 업그레이드

### 리뷰어에게 하고 싶은 말
- 언제 패치되나 2일 간격으로 확인했던것 같은데 하필 딱 포기하고 재작업 하려고 하니 갑자기 패치 올라왔네요 ㅋㅋㅋ
- 앓던이가 빠진느낌이라 좋네요